### PR TITLE
Added a code to remove Kindle watermark.

### DIFF
--- a/DeDRM_Windows_Application/DeDRM_App/DeDRM_lib/lib/mobidedrm.py
+++ b/DeDRM_Windows_Application/DeDRM_App/DeDRM_lib/lib/mobidedrm.py
@@ -69,9 +69,10 @@
 #  0.39 - Fixed problem with TEXtREAd and getBookType interface
 #  0.40 - moved unicode_argv call inside main for Windows DeDRM compatibility
 #  0.41 - Fixed potential unicode problem in command line calls
+#  0.42 - Added watermark removing code
 
 
-__version__ = u"0.41"
+__version__ = u"0.42"
 
 import sys
 import os
@@ -317,6 +318,9 @@ class MobiBook:
                     elif type == 404 and size == 9:
                         # make sure text to speech is enabled
                         self.patchSection(0, '\0', 16 + self.mobi_length + pos + 8)
+                    elif type == 208 and size == 219:
+                        # remove watermark (atv:kin: stuff)
+                        self.patchSection(0, '\0'*211, 16 + self.mobi_length + pos + 8)
                     # print type, size, content, content.encode('hex')
                     pos += size
         except:


### PR DESCRIPTION
Not that watermark thing is very important for personal use, but its value can be different in two ebooks from the same Amazon account and that creates a major headache when comparing ebooks, for example (I use hashes to figure out was an ebook updated or not, and watermark very often causes false-positives).

Some details http://www.mobileread.com/forums/showthread.php?t=168324

Probably there are other ways for Amazon to mark the content and it needs further investigation (the main test would be to take two copies of the same ebook purchased by two different people, and compare after decrypting and removing the mark), but this small patch might be good enough for now.