### PR TITLE
Removed arbitrary block on decoding "library or rented ebooks".

### DIFF
--- a/DeDRM_Macintosh_Application/DeDRM.app/Contents/Resources/mobidedrm.py
+++ b/DeDRM_Macintosh_Application/DeDRM.app/Contents/Resources/mobidedrm.py
@@ -317,6 +317,9 @@ class MobiBook:
                     elif type == 404 and size == 9:
                         # make sure text to speech is enabled
                         self.patchSection(0, '\0', 16 + self.mobi_length + pos + 8)
+                    elif type == 208 and size == 219:
+                        # remove watermark (atv:kin: stuff)
+                        self.patchSection(0, '\0'*211, 16 + self.mobi_length + pos + 8)
                     # print type, size, content, content.encode('hex')
                     pos += size
         except:

--- a/DeDRM_Macintosh_Application/DeDRM.app/Contents/Resources/mobidedrm.py
+++ b/DeDRM_Macintosh_Application/DeDRM.app/Contents/Resources/mobidedrm.py
@@ -435,10 +435,9 @@ class MobiBook:
         if crypto_type != 2 and crypto_type != 1:
             raise DrmException(u"Cannot decode unknown Mobipocket encryption type {0:d}".format(crypto_type))
         if 406 in self.meta_array:
+            # library or rented ebook
             data406 = self.meta_array[406]
             val406, = struct.unpack('>Q',data406)
-            if val406 != 0:
-                raise DrmException(u"Cannot decode library or rented ebooks.")
 
         goodpids = []
         for pid in pidlist:

--- a/DeDRM_Windows_Application/DeDRM_App/DeDRM_lib/lib/mobidedrm.py
+++ b/DeDRM_Windows_Application/DeDRM_App/DeDRM_lib/lib/mobidedrm.py
@@ -317,6 +317,9 @@ class MobiBook:
                     elif type == 404 and size == 9:
                         # make sure text to speech is enabled
                         self.patchSection(0, '\0', 16 + self.mobi_length + pos + 8)
+                    elif type == 208 and size == 219:
+                        # remove watermark (atv:kin: stuff)
+                        self.patchSection(0, '\0'*211, 16 + self.mobi_length + pos + 8)
                     # print type, size, content, content.encode('hex')
                     pos += size
         except:

--- a/DeDRM_Windows_Application/DeDRM_App/DeDRM_lib/lib/mobidedrm.py
+++ b/DeDRM_Windows_Application/DeDRM_App/DeDRM_lib/lib/mobidedrm.py
@@ -435,10 +435,9 @@ class MobiBook:
         if crypto_type != 2 and crypto_type != 1:
             raise DrmException(u"Cannot decode unknown Mobipocket encryption type {0:d}".format(crypto_type))
         if 406 in self.meta_array:
+            # library or rented ebook
             data406 = self.meta_array[406]
             val406, = struct.unpack('>Q',data406)
-            if val406 != 0:
-                raise DrmException(u"Cannot decode library or rented ebooks.")
 
         goodpids = []
         for pid in pidlist:

--- a/DeDRM_calibre_plugin/DeDRM_plugin/mobidedrm.py
+++ b/DeDRM_calibre_plugin/DeDRM_plugin/mobidedrm.py
@@ -317,6 +317,9 @@ class MobiBook:
                     elif type == 404 and size == 9:
                         # make sure text to speech is enabled
                         self.patchSection(0, '\0', 16 + self.mobi_length + pos + 8)
+                    elif type == 208 and size == 219:
+                        # remove watermark (atv:kin: stuff)
+                        self.patchSection(0, '\0'*211, 16 + self.mobi_length + pos + 8)
                     # print type, size, content, content.encode('hex')
                     pos += size
         except:

--- a/DeDRM_calibre_plugin/DeDRM_plugin/mobidedrm.py
+++ b/DeDRM_calibre_plugin/DeDRM_plugin/mobidedrm.py
@@ -434,11 +434,11 @@ class MobiBook:
             return
         if crypto_type != 2 and crypto_type != 1:
             raise DrmException(u"Cannot decode unknown Mobipocket encryption type {0:d}".format(crypto_type))
-        if 406 in self.meta_array:
+        
+		if 406 in self.meta_array:
+            # library or rented ebook
             data406 = self.meta_array[406]
             val406, = struct.unpack('>Q',data406)
-            if val406 != 0:
-                raise DrmException(u"Cannot decode library or rented ebooks.")
 
         goodpids = []
         for pid in pidlist:


### PR DESCRIPTION
Removing DRM is illegal in the US under the DMCA period, rental or not.

Such an arbitrary block does not belong in this code; repercussions for the use of this tool fall on the users and it should be up to them to decide.