### PR TITLE
Linux: Allow using ~ when specifying a wineprefix.

### DIFF
--- a/DeDRM_calibre_plugin/DeDRM_plugin/wineutils.py
+++ b/DeDRM_calibre_plugin/DeDRM_plugin/wineutils.py
@@ -26,6 +26,7 @@ def WineGetKeys(scriptpath, extension, wineprefix=""):
     if not os.path.exists(outdirpath):
         os.makedirs(outdirpath)
 
+    wineprefix = os.path.abspath(os.path.expanduser(os.path.expandvars(wineprefix)))
     if wineprefix != "" and os.path.exists(wineprefix):
          cmdline = u"WINEPREFIX=\"{2}\" wine python.exe \"{0}\" \"{1}\"".format(scriptpath,outdirpath,wineprefix)
     else:


### PR DESCRIPTION
Found this a while back, but never got around to mentioning it... I stupidly figured it wasn't a big deal.

This fixes #25