### PR TITLE
improvements in the obok device handling

### DIFF
--- a/Obok_calibre_plugin/obok_plugin/obok/obok.py
+++ b/Obok_calibre_plugin/obok_plugin/obok/obok.py
@@ -248,29 +248,31 @@ class KoboLibrary(object):
         print u"Obok v{0}\nCopyright © 2012-2015 Physisticated et al.".format(__version__)
         self.kobodir = ''
         kobodb = ''
-        if sys.platform.startswith('win'):
-            if sys.getwindowsversion().major > 5:
-                self.kobodir = os.environ['LOCALAPPDATA']
-            else:
-                self.kobodir = os.path.join(os.environ['USERPROFILE'], 'Local Settings', 'Application Data')
-            self.kobodir = os.path.join(self.kobodir, 'Kobo', 'Kobo Desktop Edition')
-        elif sys.platform.startswith('darwin'):
-            self.kobodir = os.path.join(os.environ['HOME'], 'Library', 'Application Support', 'Kobo', 'Kobo Desktop Edition')
-        # desktop versions use Kobo.sqlite
-        kobodb = os.path.join(self.kobodir, 'Kobo.sqlite')
-        if (self.kobodir == '' or not(os.path.exists(kobodb))):
-            # kobodb is either not set or not an existing file, that means that either:
-            # . windows or mac: desktop app is not installed
-            # . linux
-            # we check for a connected device and try to set up kobodir and kobodb from there
-            if (device_path):
-                self.kobodir = os.path.join(device_path, '.kobo')
-                # devices use KoboReader.sqlite
-                kobodb  = os.path.join(self.kobodir, 'KoboReader.sqlite')
-                if (not(os.path.exists(kobodb))):
-                    # give up here, we haven't found anything useful
-                    self.kobodir = ''
-                    kobodb  = ''
+
+        # - first check whether serials have been found or are provided 
+        #   and a device is connected. In this case, use the device
+        # - otherwise fall back to Kobo Desktop Application for Windows and Mac
+        if (device_path and (len(serials) > 0)):
+            self.kobodir = os.path.join(device_path, '.kobo')
+            # devices use KoboReader.sqlite
+            kobodb  = os.path.join(self.kobodir, 'KoboReader.sqlite')
+            if (not(os.path.exists(kobodb))):
+                # give up here, we haven't found anything useful
+                self.kobodir = ''
+                kobodb  = ''
+
+        if (self.kobodir == ''):
+            # we haven't found a device with serials, so try desktop apps
+            if sys.platform.startswith('win'):
+                if sys.getwindowsversion().major > 5:
+                    self.kobodir = os.environ['LOCALAPPDATA']
+                else:
+                    self.kobodir = os.path.join(os.environ['USERPROFILE'], 'Local Settings', 'Application Data')
+                self.kobodir = os.path.join(self.kobodir, 'Kobo', 'Kobo Desktop Edition')
+            elif sys.platform.startswith('darwin'):
+                self.kobodir = os.path.join(os.environ['HOME'], 'Library', 'Application Support', 'Kobo', 'Kobo Desktop Edition')
+            # desktop versions use Kobo.sqlite
+            kobodb = os.path.join(self.kobodir, 'Kobo.sqlite')
         
         if (self.kobodir != ''):
             self.bookdir = os.path.join(self.kobodir, 'kepub')


### PR DESCRIPTION
Hi
thanks for your comments in the other pull request. I have no added two commit that implement the changes you requested:
* get the device serial from the device if possible. I keep the old code to manually configure the device in case the device id cannot be found via the adobe_digitaleditions directory.
* revert the order of usage: first try a connected device (but only if there are also serials), otherwise try the desktop programs on WIndows and Mac

Tested on Windows and Mac as before.

Concerning your comment on the change/removal of `encode('ascii', 'ignore')` : this is actually a noop in this setting, as the obok calibre plugin never uses the cli_main function. For the standalone the proper way would be to convert the utf8 encoded strings obtained from the titles to the proper output encoding (depending on locale). I know how to do this in perl, but have no idea about how python handles multiple encodings.

All the best