### PR TITLE
obok: make sure that file exists before opening the db

### DIFF
--- a/Obok_calibre_plugin/obok_plugin/obok/obok.py
+++ b/Obok_calibre_plugin/obok_plugin/obok/obok.py
@@ -260,7 +260,7 @@ class KoboLibrary(object):
             self.kobodir = os.path.join(device_path, u".kobo")
             # devices use KoboReader.sqlite
             kobodb  = os.path.join(self.kobodir, u"KoboReader.sqlite")
-            if (not(os.path.exists(kobodb))):
+            if (not(os.path.isfile(kobodb))):
                 # give up here, we haven't found anything useful
                 self.kobodir = u""
                 kobodb  = u""
@@ -282,6 +282,12 @@ class KoboLibrary(object):
                 self.kobodir = os.path.join(os.environ['HOME'], u"Library", u"Application Support", u"Kobo", u"Kobo Desktop Edition")
             # desktop versions use Kobo.sqlite
             kobodb = os.path.join(self.kobodir, u"Kobo.sqlite")
+            # check for existence of file
+            if (not(os.path.isfile(kobodb))):
+                # give up here, we haven't found anything useful
+                self.kobodir = u""
+                kobodb  = u""
+
         
         if (self.kobodir != u""):
             self.bookdir = os.path.join(self.kobodir, u"kepub")


### PR DESCRIPTION
Here are two small fixes, mostly to cope with situations where neither a device is connected nor a database is found (no Kobo Desktop installed).

Included is also a change from exists to isfile for the check of the device's sqlite database.