### PR TITLE
Allow adobekey.pyw to be run under windows cygwin

### DIFF
--- a/Other_Tools/DRM_Key_Scripts/Adobe_Digital_Editions/adobekey.pyw
+++ b/Other_Tools/DRM_Key_Scripts/Adobe_Digital_Editions/adobekey.pyw
@@ -79,7 +79,7 @@ try:
     from calibre.constants import iswindows, isosx
 except:
     iswindows = sys.platform.startswith('win')
-    isosx = sys.platform.startswith('darwin')
+    isosx = sys.platform.startswith('darwin') or sys.platform.startswith('cygwin')
 
 def unicode_argv():
     if iswindows:

--- a/Other_Tools/DRM_Key_Scripts/Adobe_Digital_Editions/adobekey.pyw
+++ b/Other_Tools/DRM_Key_Scripts/Adobe_Digital_Editions/adobekey.pyw
@@ -423,7 +423,7 @@ elif isosx:
         warnings.filterwarnings('ignore', category=FutureWarning)
 
         home = os.getenv('HOME')
-        cmdline = 'find "' + home + '/Library/Application Support/Adobe/Digital Editions" -name "activation.dat"'
+        cmdline = 'find . "' + home + '/Library/Application Support/Adobe/Digital Editions" -name "activation.dat"'
         cmdline = cmdline.encode(sys.getfilesystemencoding())
         p2 = subprocess.Popen(cmdline, shell=True, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=False)
         out1, out2 = p2.communicate()


### PR DESCRIPTION
This will help cygwin users that have extracted activation.dat from a 3rd party device, ie android.

Cygwin and Linux 'find' accepts multiple search paths and works with this change - i have not tested this on a MacOS's find.