### PR TITLE
Support pylzma as a fallback

### DIFF
--- a/DeDRM_Macintosh_Application/DeDRM.app/Contents/Resources/ion.py
+++ b/DeDRM_Macintosh_Application/DeDRM.app/Contents/Resources/ion.py
@@ -23,13 +23,17 @@ from Crypto.Util.py3compat import bchr, bord
 try:
     # lzma library from calibre 2.35.0 or later
     import lzma.lzma1 as calibre_lzma
-except:
+except ImportError:
     calibre_lzma = None
     try:
         import lzma
-    except:
+    except ImportError:
         # Need pip backports.lzma on Python <3.3
-        from backports import lzma
+        try:
+            from backports import lzma
+        except ImportError:
+            # Windows-friendly choice: pylzma wheels
+            import pylzma as lzma
 
 
 TID_NULL = 0

--- a/DeDRM_Macintosh_Application/DeDRM.app/Contents/Resources/kfxdedrm.py
+++ b/DeDRM_Macintosh_Application/DeDRM.app/Contents/Resources/kfxdedrm.py
@@ -15,9 +15,9 @@ except ImportError:
     from StringIO import StringIO
 
 try:
-    import ion
-except:
     from calibre_plugins.dedrm import ion
+except ImportError:
+    import ion
 
 
 __license__ = 'GPL v3'

--- a/DeDRM_Windows_Application/DeDRM_App/DeDRM_lib/lib/ion.py
+++ b/DeDRM_Windows_Application/DeDRM_App/DeDRM_lib/lib/ion.py
@@ -23,13 +23,17 @@ from Crypto.Util.py3compat import bchr, bord
 try:
     # lzma library from calibre 2.35.0 or later
     import lzma.lzma1 as calibre_lzma
-except:
+except ImportError:
     calibre_lzma = None
     try:
         import lzma
-    except:
+    except ImportError:
         # Need pip backports.lzma on Python <3.3
-        from backports import lzma
+        try:
+            from backports import lzma
+        except ImportError:
+            # Windows-friendly choice: pylzma wheels
+            import pylzma as lzma
 
 
 TID_NULL = 0

--- a/DeDRM_Windows_Application/DeDRM_App/DeDRM_lib/lib/kfxdedrm.py
+++ b/DeDRM_Windows_Application/DeDRM_App/DeDRM_lib/lib/kfxdedrm.py
@@ -15,9 +15,9 @@ except ImportError:
     from StringIO import StringIO
 
 try:
-    import ion
-except:
     from calibre_plugins.dedrm import ion
+except ImportError:
+    import ion
 
 
 __license__ = 'GPL v3'

--- a/DeDRM_calibre_plugin/DeDRM_plugin/ion.py
+++ b/DeDRM_calibre_plugin/DeDRM_plugin/ion.py
@@ -23,13 +23,17 @@ from Crypto.Util.py3compat import bchr, bord
 try:
     # lzma library from calibre 2.35.0 or later
     import lzma.lzma1 as calibre_lzma
-except:
+except ImportError:
     calibre_lzma = None
     try:
         import lzma
-    except:
+    except ImportError:
         # Need pip backports.lzma on Python <3.3
-        from backports import lzma
+        try:
+            from backports import lzma
+        except ImportError:
+            # Windows-friendly choice: pylzma wheels
+            import pylzma as lzma
 
 
 TID_NULL = 0

--- a/DeDRM_calibre_plugin/DeDRM_plugin/kfxdedrm.py
+++ b/DeDRM_calibre_plugin/DeDRM_plugin/kfxdedrm.py
@@ -15,9 +15,9 @@ except ImportError:
     from StringIO import StringIO
 
 try:
-    import ion
-except:
     from calibre_plugins.dedrm import ion
+except ImportError:
+    import ion
 
 
 __license__ = 'GPL v3'

--- a/ReadMe_First.txt
+++ b/ReadMe_First.txt
@@ -107,6 +107,15 @@ In addition, Windows Users need PyCrypto:
 
 Once Windows users have installed Python 2.7, and the matching PyCrypto, they are ready to run the DeDRM application or individual scripts.
 
+For (experimental) KFX support, you also need LZMA support. LZMA is built-in
+in Python 3.3+ but not present in Python 2. Choices are backports.lzma and
+pylzma, both of which need compiling. Compiling Python extensions on Windows
+requires Visual Studio and is a PITA. The recommended way is to install wheels
+(binary) directly.
+
+Windows binary wheels for backports.lzma and pylzma could be found here:
+
+https://www.lfd.uci.edu/~gohlke/pythonlibs/
 
 
 Apple's iBooks FairPlay DRM


### PR DESCRIPTION
This PR adds support for pylzma, which is an alternative way to get LZMA working in Python 2.