### PR TITLE
Infer filenames consistently

### DIFF
--- a/DeDRM_Macintosh_Application/DeDRM.app/Contents/Resources/k4mobidedrm.py
+++ b/DeDRM_Macintosh_Application/DeDRM.app/Contents/Resources/k4mobidedrm.py
@@ -262,12 +262,16 @@ def decryptBook(infile, outdir, kDatabaseFiles, androidFiles, serials, pids):
         traceback.print_exc()
         return 1
 
-    # if we're saving to the same folder as the original, use file name_
-    # if to a different folder, use book name
-    if os.path.normcase(os.path.normpath(outdir)) == os.path.normcase(os.path.normpath(os.path.dirname(infile))):
-        outfilename = os.path.splitext(os.path.basename(infile))[0]
-    else:
-        outfilename = cleanup_name(book.getBookTitle())
+    # Try to infer a reasonable name
+    orig_fn_root = os.path.splitext(os.path.basename(infile))[0]
+    if (
+        re.match('^B[A-Z0-9]{9}(_EBOK|_EBSP|_sample)?$', orig_fn_root) or
+        re.match('^{0-9A-F-}{36}$', orig_fn_root)
+    ):  # Kindle for PC / Mac / Android / Fire / iOS
+        clean_title = cleanup_name(book.getBookTitle())
+        outfilename = '{}_{}'.format(orig_fn_root, clean_title)
+    else:  # E Ink Kindle, which already uses a reasonable name
+        outfilename = orig_fn_root
 
     # avoid excessively long file names
     if len(outfilename)>150:

--- a/DeDRM_Windows_Application/DeDRM_App/DeDRM_lib/lib/k4mobidedrm.py
+++ b/DeDRM_Windows_Application/DeDRM_App/DeDRM_lib/lib/k4mobidedrm.py
@@ -262,12 +262,16 @@ def decryptBook(infile, outdir, kDatabaseFiles, androidFiles, serials, pids):
         traceback.print_exc()
         return 1
 
-    # if we're saving to the same folder as the original, use file name_
-    # if to a different folder, use book name
-    if os.path.normcase(os.path.normpath(outdir)) == os.path.normcase(os.path.normpath(os.path.dirname(infile))):
-        outfilename = os.path.splitext(os.path.basename(infile))[0]
-    else:
-        outfilename = cleanup_name(book.getBookTitle())
+    # Try to infer a reasonable name
+    orig_fn_root = os.path.splitext(os.path.basename(infile))[0]
+    if (
+        re.match('^B[A-Z0-9]{9}(_EBOK|_EBSP|_sample)?$', orig_fn_root) or
+        re.match('^{0-9A-F-}{36}$', orig_fn_root)
+    ):  # Kindle for PC / Mac / Android / Fire / iOS
+        clean_title = cleanup_name(book.getBookTitle())
+        outfilename = '{}_{}'.format(orig_fn_root, clean_title)
+    else:  # E Ink Kindle, which already uses a reasonable name
+        outfilename = orig_fn_root
 
     # avoid excessively long file names
     if len(outfilename)>150:

--- a/DeDRM_calibre_plugin/DeDRM_plugin/k4mobidedrm.py
+++ b/DeDRM_calibre_plugin/DeDRM_plugin/k4mobidedrm.py
@@ -262,12 +262,16 @@ def decryptBook(infile, outdir, kDatabaseFiles, androidFiles, serials, pids):
         traceback.print_exc()
         return 1
 
-    # if we're saving to the same folder as the original, use file name_
-    # if to a different folder, use book name
-    if os.path.normcase(os.path.normpath(outdir)) == os.path.normcase(os.path.normpath(os.path.dirname(infile))):
-        outfilename = os.path.splitext(os.path.basename(infile))[0]
-    else:
-        outfilename = cleanup_name(book.getBookTitle())
+    # Try to infer a reasonable name
+    orig_fn_root = os.path.splitext(os.path.basename(infile))[0]
+    if (
+        re.match('^B[A-Z0-9]{9}(_EBOK|_EBSP|_sample)?$', orig_fn_root) or
+        re.match('^{0-9A-F-}{36}$', orig_fn_root)
+    ):  # Kindle for PC / Mac / Android / Fire / iOS
+        clean_title = cleanup_name(book.getBookTitle())
+        outfilename = '{}_{}'.format(orig_fn_root, clean_title)
+    else:  # E Ink Kindle, which already uses a reasonable name
+        outfilename = orig_fn_root
 
     # avoid excessively long file names
     if len(outfilename)>150:


### PR DESCRIPTION
Currently the filename of a decrypted book is calculated differently depending on when the original file and output file are in the same directory. This PR changes this behavior in the following ways:

1. For Kindle software, the filename is either ASIN or UUID, which is not user-friendly. So we change change it to the format of `{orig_name}_{clean_title}_nodrm.{ext}`, e.g. `B008476HBM_EBOK_Pride and Prejudice_nodrm.azw`;
2. For E Ink Kindle devices, the filename is already a concatenation of title and ASIN, so we keep it "as is".

This is a more consistent way of naming books IMHO. Feel free to reject this PR if you do not think so.