### PR TITLE
Drastically simplified and corrected primes() in src/kindlekey.py

### DIFF
--- a/src/kindlekey.py
+++ b/src/kindlekey.py
@@ -126,23 +126,26 @@ def SHA256(message):
 # For K4M/PC 1.6.X and later
 # generate table of prime number less than or equal to int n
 def primes(n):
-    if n==2: return [2]
-    elif n<2: return []
-    s=range(3,n+1,2)
-    mroot = n ** 0.5
-    half=(n+1)/2-1
-    i=0
-    m=3
-    while m <= mroot:
-        if s[i]:
-            j=(m*m-3)/2
-            s[j]=0
-            while j<half:
-                s[j]=0
-                j+=m
-        i=i+1
-        m=2*i+3
-    return [2]+[x for x in s if x]
+    """
+    Return a list of prime integers smaller than or equal to n
+    :param n: int
+    :return: list->int
+    """
+    if n == 2:
+        return [2]
+    elif n < 2:
+        return []
+    primeList = [2]
+
+    for potentialPrime in range(3, n + 1, 2):
+        isItPrime = True
+        for prime in primeList:
+            if potentialPrime % prime == 0:
+                isItPrime = False
+        if isItPrime is True:
+            primeList.append(potentialPrime)
+
+    return primeList
 
 # Encode the bytes in data with the characters in map
 def encode(data, map):

--- a/src/kindlekey.py
+++ b/src/kindlekey.py
@@ -124,7 +124,6 @@ def SHA256(message):
     return ctx.digest()
 
 # For K4M/PC 1.6.X and later
-# generate table of prime number less than or equal to int n
 def primes(n):
     """
     Return a list of prime integers smaller than or equal to n


### PR DESCRIPTION
I tested the previous code with the input 10000 and it gave me error:
```python
Traceback (most recent call last):
  File "F:/py4e/EXTRA/prac3.py", line 43, in <module>
    primes(10000)
  File "F:/py4e/EXTRA/prac3.py", line 16, in primes
    s[j] = 0
IndexError: list assignment index out of range
```
_Note: File directory is different in the above error message because I copied the func to test it individually._
Previous func was, I definitely think, very complex and had no format as well.
I refactored it and changed the algo to be much more efficient.