### PR TITLE
Fix automatic import of decryption keys on Linux with wine

### DIFF
--- a/dedrm_src/wineutils.py
+++ b/dedrm_src/wineutils.py
@@ -26,7 +26,9 @@ def WineGetKeys(scriptpath, extension, wineprefix=""):
     if not os.path.exists(outdirpath):
         os.makedirs(outdirpath)
 
-    wineprefix = os.path.abspath(os.path.expanduser(os.path.expandvars(wineprefix)))
+    if wineprefix != "":
+        wineprefix = os.path.abspath(os.path.expanduser(os.path.expandvars(wineprefix)))
+
     if wineprefix != "" and os.path.exists(wineprefix):
          cmdline = u"WINEPREFIX=\"{2}\" wine python.exe \"{0}\" \"{1}\"".format(scriptpath,outdirpath,wineprefix)
     else:


### PR DESCRIPTION
By default, the wineprefix passed to WineGetKeys is `""`. Unfortunately,

    os.path.abspath(os.path.expanduser(os.path.expandvars("")))

returns the path to the working directory, which depends on the directory from which calibre was invoked.  Hence under current behaviour the wineprefix becomes that path, no longer being the empty string.  This means that the `cmdline` that's run is always `WINEPREFIX=/some/path/ wine python.exe [...]`, rather than `wine python.exe [...]` even under default conditions, when the wineprefix hasn't been changed.  Unless the user is improbably lucky and invokes calibre from ~/.wine/ (the default wineprefix), this causes automatic retrieval of the keys to always fail.

The bug was introduced in f2190a67558a.

Checking for `""` allows for correct behaviour in the default case, while keeping the nice behaviour of expanding `~`.

BTW Thanks for the extremely useful plugin that make it possible to actually own the books that one buys!