### PR TITLE
Allow decryption with DSN only.

### DIFF
--- a/dedrm_src/kfxdedrm.py
+++ b/dedrm_src/kfxdedrm.py
@@ -68,7 +68,7 @@ class KFXZipBook:
         print u'Decrypting KFX DRM voucher: {0}'.format(info.filename)
 
         for pid in [''] + totalpids:
-            for dsn_len,secret_len in [(0,0), (16,0), (16,40), (32,40), (40,40)]:
+            for dsn_len,secret_len in [(0,0), (16,0), (16,40), (32,40), (40,0), (40,40)]:
                 if len(pid) == dsn_len + secret_len:
                     break       # split pid into DSN and account secret
             else:


### PR DESCRIPTION
Had a recently released book in KFX-ZIP format that I couldn't decrypt, from K4Mac 1.23.1.  Running under the debugger, the pid is just the 40 character dsn.  Lock parameters in the ion envelope only specify CLIENT_ID, so the secret wouldn't be used anyway.  Adding (40,0) as a possible dsn/secret length seems to do the trick.