### PR TITLE
Make it possible to paste Kindle serial no. directly from Amazon devices page

### DIFF
--- a/dedrm_src/config.py
+++ b/dedrm_src/config.py
@@ -875,11 +875,11 @@ class AddSerialDialog(QDialog):
 
     @property
     def key_name(self):
-        return unicode(self.key_ledit.text()).strip()
+        return unicode(self.key_ledit.text()).replace(' ', '')
 
     @property
     def key_value(self):
-        return unicode(self.key_ledit.text()).strip()
+        return unicode(self.key_ledit.text()).replace(' ', '')
 
     def accept(self):
         if len(self.key_name) == 0 or self.key_name.isspace():


### PR DESCRIPTION
Strip **all** spaces from added eInk Kindle Serial Numbers so it's possible to
copy/paste directly from Amazon's *Manage Your Content and Devices* page.
Previously it was necessary to manually strip whitespace, e.g.
`G000 aaaa bbbb cccc` -> `G000aaaabbbbcccc`.