### PR TITLE
Improve Python 3 compatibility

### DIFF
--- a/DeDRM_plugin/__init__.py
+++ b/DeDRM_plugin/__init__.py
@@ -90,6 +90,7 @@ import time
 import zipfile
 import traceback
 from zipfile import ZipFile
+import codecs
 
 class DeDRMError(Exception):
     pass
@@ -319,7 +320,7 @@ class DeDRM(FileTypePlugin):
 
             # Attempt to decrypt epub with each encryption key (generated or provided).
             for keyname, userkeyhex in dedrmprefs['adeptkeys'].items():
-                userkey = userkeyhex.decode('hex')
+                userkey = codecs.decode(userkeyhex, 'hex')
                 print(u"{0} v{1}: Trying Encryption key {2:s}".format(PLUGIN_NAME, PLUGIN_VERSION, keyname))
                 of = self.temporary_file(u".epub")
 
@@ -369,7 +370,7 @@ class DeDRM(FileTypePlugin):
 
             newkeys = []
             for keyvalue in defaultkeys:
-                if keyvalue.encode('hex') not in dedrmprefs['adeptkeys'].values():
+                if codecs.encode(keyvalue, 'hex').decode('ascii') not in dedrmprefs['adeptkeys'].values():
                     newkeys.append(keyvalue)
 
             if len(newkeys) > 0:
@@ -393,7 +394,7 @@ class DeDRM(FileTypePlugin):
                             # Store the new successful key in the defaults
                             print(u"{0} v{1}: Saving a new default key".format(PLUGIN_NAME, PLUGIN_VERSION))
                             try:
-                                dedrmprefs.addnamedvaluetoprefs('adeptkeys','default_key',keyvalue.encode('hex'))
+                                dedrmprefs.addnamedvaluetoprefs('adeptkeys','default_key',codecs.encode(keyvalue, 'hex').decode('ascii'))
                                 dedrmprefs.writeprefs()
                                 print(u"{0} v{1}: Saved a new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
                             except:

--- a/DeDRM_plugin/__init__.py
+++ b/DeDRM_plugin/__init__.py
@@ -113,8 +113,12 @@ class SafeUnbuffered:
         if isinstance(data,six.text_type):
             data = data.encode(self.encoding,"replace")
         try:
-            self.stream.write(data)
-            self.stream.flush()
+            if six.PY3:
+                self.stream.buffer.write(data)
+                self.stream.buffer.flush()
+            else:
+                self.stream.write(data)
+                self.stream.flush()
         except:
             # We can do nothing if a write fails
             pass

--- a/DeDRM_plugin/__init__.py
+++ b/DeDRM_plugin/__init__.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 from __future__ import absolute_import
 from __future__ import print_function
 

--- a/DeDRM_plugin/__init__.py
+++ b/DeDRM_plugin/__init__.py
@@ -2,12 +2,12 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import with_statement
+from __future__ import absolute_import
+from __future__ import print_function
 
 # __init__.py for DeDRM_plugin
 # Copyright © 2008-2020 Apprentice Harper et al.
 
-from __future__ import absolute_import
-from __future__ import print_function
 import six
 __license__   = 'GPL v3'
 __version__ = '6.8.0'
@@ -270,7 +270,7 @@ class DeDRM(FileTypePlugin):
 
             newkeys = []
             for keyvalue in defaultkeys:
-                if keyvalue not in list(dedrmprefs['bandnkeys'].values()):
+                if keyvalue not in dedrmprefs['bandnkeys'].values():
                     newkeys.append(keyvalue)
 
             if len(newkeys) > 0:
@@ -369,7 +369,7 @@ class DeDRM(FileTypePlugin):
 
             newkeys = []
             for keyvalue in defaultkeys:
-                if keyvalue.encode('hex') not in list(dedrmprefs['adeptkeys'].values()):
+                if keyvalue.encode('hex') not in dedrmprefs['adeptkeys'].values():
                     newkeys.append(keyvalue)
 
             if len(newkeys) > 0:
@@ -472,7 +472,7 @@ class DeDRM(FileTypePlugin):
 
         newkeys = []
         for keyvalue in defaultkeys:
-            if keyvalue.encode('hex') not in list(dedrmprefs['adeptkeys'].values()):
+            if keyvalue.encode('hex') not in dedrmprefs['adeptkeys'].values():
                 newkeys.append(keyvalue)
 
         if len(newkeys) > 0:
@@ -562,7 +562,7 @@ class DeDRM(FileTypePlugin):
             newkeys = {}
             for i,keyvalue in enumerate(defaultkeys):
                 keyname = u"default_key_{0:d}".format(i+1)
-                if keyvalue not in list(dedrmprefs['kindlekeys'].values()):
+                if keyvalue not in dedrmprefs['kindlekeys'].values():
                     newkeys[keyname] = keyvalue
             if len(newkeys) > 0:
                 print(u"{0} v{1}: Found {2} new {3}".format(PLUGIN_NAME, PLUGIN_VERSION, len(newkeys), u"key" if len(newkeys)==1 else u"keys"))

--- a/DeDRM_plugin/__init__.py
+++ b/DeDRM_plugin/__init__.py
@@ -6,6 +6,9 @@ from __future__ import with_statement
 # __init__.py for DeDRM_plugin
 # Copyright © 2008-2020 Apprentice Harper et al.
 
+from __future__ import absolute_import
+from __future__ import print_function
+import six
 __license__   = 'GPL v3'
 __version__ = '6.8.0'
 __docformat__ = 'restructuredtext en'
@@ -78,7 +81,7 @@ Decrypt DRMed ebooks.
 
 PLUGIN_NAME = u"DeDRM"
 PLUGIN_VERSION_TUPLE = (6, 8, 0)
-PLUGIN_VERSION = u".".join([unicode(str(x)) for x in PLUGIN_VERSION_TUPLE])
+PLUGIN_VERSION = u".".join([six.text_type(str(x)) for x in PLUGIN_VERSION_TUPLE])
 # Include an html helpfile in the plugin's zipfile with the following name.
 RESOURCE_NAME = PLUGIN_NAME + '_Help.htm'
 
@@ -107,7 +110,7 @@ class SafeUnbuffered:
         if self.encoding == None:
             self.encoding = "utf-8"
     def write(self, data):
-        if isinstance(data,unicode):
+        if isinstance(data,six.text_type):
             data = data.encode(self.encoding,"replace")
         try:
             self.stream.write(data)
@@ -165,7 +168,7 @@ class DeDRM(FileTypePlugin):
                 else:
                     names = [u"libalfcrypto32.so",u"libalfcrypto64.so",u"kindlekey.py",u"adobekey.py",u"subasyncio.py"]
                 lib_dict = self.load_resources(names)
-                print u"{0} v{1}: Copying needed library files from plugin's zip".format(PLUGIN_NAME, PLUGIN_VERSION)
+                print(u"{0} v{1}: Copying needed library files from plugin's zip".format(PLUGIN_NAME, PLUGIN_VERSION))
 
                 for entry, data in lib_dict.items():
                     file_path = os.path.join(self.alfdir, entry)
@@ -177,7 +180,7 @@ class DeDRM(FileTypePlugin):
                     try:
                         open(file_path,'wb').write(data)
                     except:
-                        print u"{0} v{1}: Exception when copying needed library files".format(PLUGIN_NAME, PLUGIN_VERSION)
+                        print(u"{0} v{1}: Exception when copying needed library files".format(PLUGIN_NAME, PLUGIN_VERSION))
                         traceback.print_exc()
                         pass
 
@@ -187,7 +190,7 @@ class DeDRM(FileTypePlugin):
 
                 # mark that this version has been initialized
                 os.mkdir(self.verdir)
-        except Exception, e:
+        except Exception as e:
             traceback.print_exc()
             raise
 
@@ -198,11 +201,11 @@ class DeDRM(FileTypePlugin):
 
         inf = self.temporary_file(u".epub")
         try:
-            print u"{0} v{1}: Verifying zip archive integrity".format(PLUGIN_NAME, PLUGIN_VERSION)
+            print(u"{0} v{1}: Verifying zip archive integrity".format(PLUGIN_NAME, PLUGIN_VERSION))
             fr = zipfix.fixZip(path_to_ebook, inf.name)
             fr.fix()
-        except Exception, e:
-            print u"{0} v{1}: Error \'{2}\' when checking zip archive".format(PLUGIN_NAME, PLUGIN_VERSION, e.args[0])
+        except Exception as e:
+            print(u"{0} v{1}: Error \'{2}\' when checking zip archive".format(PLUGIN_NAME, PLUGIN_VERSION, e.args[0]))
             raise Exception(e)
 
         # import the decryption keys
@@ -215,19 +218,19 @@ class DeDRM(FileTypePlugin):
 
         #check the book
         if  ignobleepub.ignobleBook(inf.name):
-            print u"{0} v{1}: “{2}” is a secure Barnes & Noble ePub".format(PLUGIN_NAME, PLUGIN_VERSION, os.path.basename(path_to_ebook))
+            print(u"{0} v{1}: “{2}” is a secure Barnes & Noble ePub".format(PLUGIN_NAME, PLUGIN_VERSION, os.path.basename(path_to_ebook)))
 
             # Attempt to decrypt epub with each encryption key (generated or provided).
             for keyname, userkey in dedrmprefs['bandnkeys'].items():
                 keyname_masked = u"".join((u'X' if (x.isdigit()) else x) for x in keyname)
-                print u"{0} v{1}: Trying Encryption key {2:s}".format(PLUGIN_NAME, PLUGIN_VERSION, keyname_masked)
+                print(u"{0} v{1}: Trying Encryption key {2:s}".format(PLUGIN_NAME, PLUGIN_VERSION, keyname_masked))
                 of = self.temporary_file(u".epub")
 
                 # Give the user key, ebook and TemporaryPersistent file to the decryption function.
                 try:
                     result = ignobleepub.decryptBook(userkey, inf.name, of.name)
                 except:
-                    print u"{0} v{1}: Exception when trying to decrypt after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+                    print(u"{0} v{1}: Exception when trying to decrypt after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
                     traceback.print_exc()
                     result = 1
 
@@ -238,10 +241,10 @@ class DeDRM(FileTypePlugin):
                     # Return the modified PersistentTemporary file to calibre.
                     return of.name
 
-                print u"{0} v{1}: Failed to decrypt with key {2:s} after {3:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,keyname_masked,time.time()-self.starttime)
+                print(u"{0} v{1}: Failed to decrypt with key {2:s} after {3:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,keyname_masked,time.time()-self.starttime))
 
             # perhaps we should see if we can get a key from a log file
-            print u"{0} v{1}: Looking for new NOOK Study Keys after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+            print(u"{0} v{1}: Looking for new NOOK Study Keys after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
 
             # get the default NOOK Study keys
             defaultkeys = []
@@ -252,24 +255,24 @@ class DeDRM(FileTypePlugin):
 
                     defaultkeys = nookkeys()
                 else: # linux
-                    from wineutils import WineGetKeys
+                    from .wineutils import WineGetKeys
 
                     scriptpath = os.path.join(self.alfdir,u"ignoblekey.py")
                     defaultkeys = WineGetKeys(scriptpath, u".b64",dedrmprefs['adobewineprefix'])
 
             except:
-                print u"{0} v{1}: Exception when getting default NOOK Study Key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+                print(u"{0} v{1}: Exception when getting default NOOK Study Key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
                 traceback.print_exc()
 
             newkeys = []
             for keyvalue in defaultkeys:
-                if keyvalue not in dedrmprefs['bandnkeys'].values():
+                if keyvalue not in list(dedrmprefs['bandnkeys'].values()):
                     newkeys.append(keyvalue)
 
             if len(newkeys) > 0:
                 try:
                     for i,userkey in enumerate(newkeys):
-                        print u"{0} v{1}: Trying a new default key".format(PLUGIN_NAME, PLUGIN_VERSION)
+                        print(u"{0} v{1}: Trying a new default key".format(PLUGIN_NAME, PLUGIN_VERSION))
 
                         of = self.temporary_file(u".epub")
 
@@ -277,7 +280,7 @@ class DeDRM(FileTypePlugin):
                         try:
                             result = ignobleepub.decryptBook(userkey, inf.name, of.name)
                         except:
-                           print u"{0} v{1}: Exception when trying to decrypt after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+                           print(u"{0} v{1}: Exception when trying to decrypt after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
                            traceback.print_exc()
                            result = 1
 
@@ -286,59 +289,59 @@ class DeDRM(FileTypePlugin):
                         if result == 0:
                             # Decryption was a success
                             # Store the new successful key in the defaults
-                            print u"{0} v{1}: Saving a new default key".format(PLUGIN_NAME, PLUGIN_VERSION)
+                            print(u"{0} v{1}: Saving a new default key".format(PLUGIN_NAME, PLUGIN_VERSION))
                             try:
                                 dedrmprefs.addnamedvaluetoprefs('bandnkeys','nook_Study_key',keyvalue)
                                 dedrmprefs.writeprefs()
-                                print u"{0} v{1}: Saved a new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime)
+                                print(u"{0} v{1}: Saved a new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
                             except:
-                                print u"{0} v{1}: Exception saving a new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+                                print(u"{0} v{1}: Exception saving a new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
                                 traceback.print_exc()
                             # Return the modified PersistentTemporary file to calibre.
                             return of.name
 
-                        print u"{0} v{1}: Failed to decrypt with new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime)
-                except Exception, e:
+                        print(u"{0} v{1}: Failed to decrypt with new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
+                except Exception as e:
                     pass
 
-            print u"{0} v{1}: Ultimately failed to decrypt after {2:.1f} seconds. Read the FAQs at Harper's repository: https://github.com/apprenticeharper/DeDRM_tools/blob/master/FAQs.md".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime)
+            print(u"{0} v{1}: Ultimately failed to decrypt after {2:.1f} seconds. Read the FAQs at Harper's repository: https://github.com/apprenticeharper/DeDRM_tools/blob/master/FAQs.md".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
             raise DeDRMError(u"{0} v{1}: Ultimately failed to decrypt after {2:.1f} seconds. Read the FAQs at Harper's repository: https://github.com/apprenticeharper/DeDRM_tools/blob/master/FAQs.md".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
 
         # import the Adobe Adept ePub handler
         import calibre_plugins.dedrm.ineptepub as ineptepub
 
         if ineptepub.adeptBook(inf.name):
-            print u"{0} v{1}: {2} is a secure Adobe Adept ePub".format(PLUGIN_NAME, PLUGIN_VERSION, os.path.basename(path_to_ebook))
+            print(u"{0} v{1}: {2} is a secure Adobe Adept ePub".format(PLUGIN_NAME, PLUGIN_VERSION, os.path.basename(path_to_ebook)))
 
             # Attempt to decrypt epub with each encryption key (generated or provided).
             for keyname, userkeyhex in dedrmprefs['adeptkeys'].items():
                 userkey = userkeyhex.decode('hex')
-                print u"{0} v{1}: Trying Encryption key {2:s}".format(PLUGIN_NAME, PLUGIN_VERSION, keyname)
+                print(u"{0} v{1}: Trying Encryption key {2:s}".format(PLUGIN_NAME, PLUGIN_VERSION, keyname))
                 of = self.temporary_file(u".epub")
 
                 # Give the user key, ebook and TemporaryPersistent file to the decryption function.
                 try:
                     result = ineptepub.decryptBook(userkey, inf.name, of.name)
                 except:
-                    print u"{0} v{1}: Exception when decrypting after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+                    print(u"{0} v{1}: Exception when decrypting after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
                     traceback.print_exc()
                     result = 1
 
                 try:
                     of.close()
                 except:
-                    print u"{0} v{1}: Exception closing temporary file after {2:.1f} seconds. Ignored.".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+                    print(u"{0} v{1}: Exception closing temporary file after {2:.1f} seconds. Ignored.".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
 
                 if  result == 0:
                     # Decryption was successful.
                     # Return the modified PersistentTemporary file to calibre.
-                    print u"{0} v{1}: Decrypted with key {2:s} after {3:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,keyname,time.time()-self.starttime)
+                    print(u"{0} v{1}: Decrypted with key {2:s} after {3:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,keyname,time.time()-self.starttime))
                     return of.name
 
-                print u"{0} v{1}: Failed to decrypt with key {2:s} after {3:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,keyname,time.time()-self.starttime)
+                print(u"{0} v{1}: Failed to decrypt with key {2:s} after {3:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,keyname,time.time()-self.starttime))
 
             # perhaps we need to get a new default ADE key
-            print u"{0} v{1}: Looking for new default Adobe Digital Editions Keys after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+            print(u"{0} v{1}: Looking for new default Adobe Digital Editions Keys after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
 
             # get the default Adobe keys
             defaultkeys = []
@@ -349,33 +352,33 @@ class DeDRM(FileTypePlugin):
 
                     defaultkeys = adeptkeys()
                 else: # linux
-                    from wineutils import WineGetKeys
+                    from .wineutils import WineGetKeys
 
                     scriptpath = os.path.join(self.alfdir,u"adobekey.py")
                     defaultkeys = WineGetKeys(scriptpath, u".der",dedrmprefs['adobewineprefix'])
 
                 self.default_key = defaultkeys[0]
             except:
-                print u"{0} v{1}: Exception when getting default Adobe Key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+                print(u"{0} v{1}: Exception when getting default Adobe Key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
                 traceback.print_exc()
                 self.default_key = u""
 
             newkeys = []
             for keyvalue in defaultkeys:
-                if keyvalue.encode('hex') not in dedrmprefs['adeptkeys'].values():
+                if keyvalue.encode('hex') not in list(dedrmprefs['adeptkeys'].values()):
                     newkeys.append(keyvalue)
 
             if len(newkeys) > 0:
                 try:
                     for i,userkey in enumerate(newkeys):
-                        print u"{0} v{1}: Trying a new default key".format(PLUGIN_NAME, PLUGIN_VERSION)
+                        print(u"{0} v{1}: Trying a new default key".format(PLUGIN_NAME, PLUGIN_VERSION))
                         of = self.temporary_file(u".epub")
 
                         # Give the user key, ebook and TemporaryPersistent file to the decryption function.
                         try:
                             result = ineptepub.decryptBook(userkey, inf.name, of.name)
                         except:
-                            print u"{0} v{1}: Exception when decrypting after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+                            print(u"{0} v{1}: Exception when decrypting after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
                             traceback.print_exc()
                             result = 1
 
@@ -384,31 +387,31 @@ class DeDRM(FileTypePlugin):
                         if  result == 0:
                             # Decryption was a success
                             # Store the new successful key in the defaults
-                            print u"{0} v{1}: Saving a new default key".format(PLUGIN_NAME, PLUGIN_VERSION)
+                            print(u"{0} v{1}: Saving a new default key".format(PLUGIN_NAME, PLUGIN_VERSION))
                             try:
                                 dedrmprefs.addnamedvaluetoprefs('adeptkeys','default_key',keyvalue.encode('hex'))
                                 dedrmprefs.writeprefs()
-                                print u"{0} v{1}: Saved a new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime)
+                                print(u"{0} v{1}: Saved a new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
                             except:
-                                print u"{0} v{1}: Exception when saving a new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+                                print(u"{0} v{1}: Exception when saving a new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
                                 traceback.print_exc()
-                            print u"{0} v{1}: Decrypted with new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime)
+                            print(u"{0} v{1}: Decrypted with new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
                             # Return the modified PersistentTemporary file to calibre.
                             return of.name
 
-                        print u"{0} v{1}: Failed to decrypt with new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime)
-                except Exception, e:
-                    print u"{0} v{1}: Unexpected Exception trying a new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+                        print(u"{0} v{1}: Failed to decrypt with new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
+                except Exception as e:
+                    print(u"{0} v{1}: Unexpected Exception trying a new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
                     traceback.print_exc()
                     pass
 
             # Something went wrong with decryption.
-            print u"{0} v{1}: Ultimately failed to decrypt after {2:.1f} seconds. Read the FAQs at Harper's repository: https://github.com/apprenticeharper/DeDRM_tools/blob/master/FAQs.md".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime)
+            print(u"{0} v{1}: Ultimately failed to decrypt after {2:.1f} seconds. Read the FAQs at Harper's repository: https://github.com/apprenticeharper/DeDRM_tools/blob/master/FAQs.md".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
             raise DeDRMError(u"{0} v{1}: Ultimately failed to decrypt after {2:.1f} seconds. Read the FAQs at Harper's repository: https://github.com/apprenticeharper/DeDRM_tools/blob/master/FAQs.md".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
 
         # Not a Barnes & Noble nor an Adobe Adept
         # Import the fixed epub.
-        print u"{0} v{1}: “{2}” is neither an Adobe Adept nor a Barnes & Noble encrypted ePub".format(PLUGIN_NAME, PLUGIN_VERSION, os.path.basename(path_to_ebook))
+        print(u"{0} v{1}: “{2}” is neither an Adobe Adept nor a Barnes & Noble encrypted ePub".format(PLUGIN_NAME, PLUGIN_VERSION, os.path.basename(path_to_ebook)))
         raise DeDRMError(u"{0} v{1}: Couldn't decrypt after {2:.1f} seconds. DRM free perhaps?".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
 
     def PDFDecrypt(self,path_to_ebook):
@@ -417,17 +420,17 @@ class DeDRM(FileTypePlugin):
 
         dedrmprefs = prefs.DeDRM_Prefs()
         # Attempt to decrypt epub with each encryption key (generated or provided).
-        print u"{0} v{1}: {2} is a PDF ebook".format(PLUGIN_NAME, PLUGIN_VERSION, os.path.basename(path_to_ebook))
+        print(u"{0} v{1}: {2} is a PDF ebook".format(PLUGIN_NAME, PLUGIN_VERSION, os.path.basename(path_to_ebook)))
         for keyname, userkeyhex in dedrmprefs['adeptkeys'].items():
             userkey = userkeyhex.decode('hex')
-            print u"{0} v{1}: Trying Encryption key {2:s}".format(PLUGIN_NAME, PLUGIN_VERSION, keyname)
+            print(u"{0} v{1}: Trying Encryption key {2:s}".format(PLUGIN_NAME, PLUGIN_VERSION, keyname))
             of = self.temporary_file(u".pdf")
 
             # Give the user key, ebook and TemporaryPersistent file to the decryption function.
             try:
                 result = ineptpdf.decryptBook(userkey, path_to_ebook, of.name)
             except:
-                print u"{0} v{1}: Exception when decrypting after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+                print(u"{0} v{1}: Exception when decrypting after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
                 traceback.print_exc()
                 result = 1
 
@@ -438,10 +441,10 @@ class DeDRM(FileTypePlugin):
                 # Return the modified PersistentTemporary file to calibre.
                 return of.name
 
-            print u"{0} v{1}: Failed to decrypt with key {2:s} after {3:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,keyname,time.time()-self.starttime)
+            print(u"{0} v{1}: Failed to decrypt with key {2:s} after {3:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,keyname,time.time()-self.starttime))
 
         # perhaps we need to get a new default ADE key
-        print u"{0} v{1}: Looking for new default Adobe Digital Editions Keys after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+        print(u"{0} v{1}: Looking for new default Adobe Digital Editions Keys after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
 
         # get the default Adobe keys
         defaultkeys = []
@@ -452,33 +455,33 @@ class DeDRM(FileTypePlugin):
 
                 defaultkeys = adeptkeys()
             else: # linux
-                from wineutils import WineGetKeys
+                from .wineutils import WineGetKeys
 
                 scriptpath = os.path.join(self.alfdir,u"adobekey.py")
                 defaultkeys = WineGetKeys(scriptpath, u".der",dedrmprefs['adobewineprefix'])
 
             self.default_key = defaultkeys[0]
         except:
-            print u"{0} v{1}: Exception when getting default Adobe Key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+            print(u"{0} v{1}: Exception when getting default Adobe Key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
             traceback.print_exc()
             self.default_key = u""
 
         newkeys = []
         for keyvalue in defaultkeys:
-            if keyvalue.encode('hex') not in dedrmprefs['adeptkeys'].values():
+            if keyvalue.encode('hex') not in list(dedrmprefs['adeptkeys'].values()):
                 newkeys.append(keyvalue)
 
         if len(newkeys) > 0:
             try:
                 for i,userkey in enumerate(newkeys):
-                    print u"{0} v{1}: Trying a new default key".format(PLUGIN_NAME, PLUGIN_VERSION)
+                    print(u"{0} v{1}: Trying a new default key".format(PLUGIN_NAME, PLUGIN_VERSION))
                     of = self.temporary_file(u".pdf")
 
                     # Give the user key, ebook and TemporaryPersistent file to the decryption function.
                     try:
                         result = ineptpdf.decryptBook(userkey, path_to_ebook, of.name)
                     except:
-                        print u"{0} v{1}: Exception when decrypting after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+                        print(u"{0} v{1}: Exception when decrypting after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
                         traceback.print_exc()
                         result = 1
 
@@ -487,23 +490,23 @@ class DeDRM(FileTypePlugin):
                     if  result == 0:
                         # Decryption was a success
                         # Store the new successful key in the defaults
-                        print u"{0} v{1}: Saving a new default key".format(PLUGIN_NAME, PLUGIN_VERSION)
+                        print(u"{0} v{1}: Saving a new default key".format(PLUGIN_NAME, PLUGIN_VERSION))
                         try:
                             dedrmprefs.addnamedvaluetoprefs('adeptkeys','default_key',keyvalue.encode('hex'))
                             dedrmprefs.writeprefs()
-                            print u"{0} v{1}: Saved a new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime)
+                            print(u"{0} v{1}: Saved a new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
                         except:
-                            print u"{0} v{1}: Exception when saving a new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+                            print(u"{0} v{1}: Exception when saving a new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
                             traceback.print_exc()
                         # Return the modified PersistentTemporary file to calibre.
                         return of.name
 
-                    print u"{0} v{1}: Failed to decrypt with new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime)
-            except Exception, e:
+                    print(u"{0} v{1}: Failed to decrypt with new default key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
+            except Exception as e:
                 pass
 
         # Something went wrong with decryption.
-        print u"{0} v{1}: Ultimately failed to decrypt after {2:.1f} seconds. Read the FAQs at Harper's repository: https://github.com/apprenticeharper/DeDRM_tools/blob/master/FAQs.md".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime)
+        print(u"{0} v{1}: Ultimately failed to decrypt after {2:.1f} seconds. Read the FAQs at Harper's repository: https://github.com/apprenticeharper/DeDRM_tools/blob/master/FAQs.md".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
         raise DeDRMError(u"{0} v{1}: Ultimately failed to decrypt after {2:.1f} seconds. Read the FAQs at Harper's repository: https://github.com/apprenticeharper/DeDRM_tools/blob/master/FAQs.md".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
 
 
@@ -526,16 +529,16 @@ class DeDRM(FileTypePlugin):
             serials.extend(android_serials_list)
         #print serials
         androidFiles = []
-        kindleDatabases = dedrmprefs['kindlekeys'].items()
+        kindleDatabases = list(dedrmprefs['kindlekeys'].items())
 
         try:
             book = k4mobidedrm.GetDecryptedBook(path_to_ebook,kindleDatabases,androidFiles,serials,pids,self.starttime)
-        except Exception, e:
+        except Exception as e:
             decoded = False
             # perhaps we need to get a new default Kindle for Mac/PC key
             defaultkeys = []
-            print u"{0} v{1}: Failed to decrypt with error: {2}".format(PLUGIN_NAME, PLUGIN_VERSION,e.args[0])
-            print u"{0} v{1}: Looking for new default Kindle Key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+            print(u"{0} v{1}: Failed to decrypt with error: {2}".format(PLUGIN_NAME, PLUGIN_VERSION,e.args[0]))
+            print(u"{0} v{1}: Looking for new default Kindle Key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
 
             try:
                 if iswindows or isosx:
@@ -543,35 +546,35 @@ class DeDRM(FileTypePlugin):
 
                     defaultkeys = kindlekeys()
                 else: # linux
-                    from wineutils import WineGetKeys
+                    from .wineutils import WineGetKeys
 
                     scriptpath = os.path.join(self.alfdir,u"kindlekey.py")
                     defaultkeys = WineGetKeys(scriptpath, u".k4i",dedrmprefs['kindlewineprefix'])
             except:
-                print u"{0} v{1}: Exception when getting default Kindle Key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime)
+                print(u"{0} v{1}: Exception when getting default Kindle Key after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
                 traceback.print_exc()
                 pass
 
             newkeys = {}
             for i,keyvalue in enumerate(defaultkeys):
                 keyname = u"default_key_{0:d}".format(i+1)
-                if keyvalue not in dedrmprefs['kindlekeys'].values():
+                if keyvalue not in list(dedrmprefs['kindlekeys'].values()):
                     newkeys[keyname] = keyvalue
             if len(newkeys) > 0:
-                print u"{0} v{1}: Found {2} new {3}".format(PLUGIN_NAME, PLUGIN_VERSION, len(newkeys), u"key" if len(newkeys)==1 else u"keys")
+                print(u"{0} v{1}: Found {2} new {3}".format(PLUGIN_NAME, PLUGIN_VERSION, len(newkeys), u"key" if len(newkeys)==1 else u"keys"))
                 try:
-                    book = k4mobidedrm.GetDecryptedBook(path_to_ebook,newkeys.items(),[],[],[],self.starttime)
+                    book = k4mobidedrm.GetDecryptedBook(path_to_ebook,list(newkeys.items()),[],[],[],self.starttime)
                     decoded = True
                     # store the new successful keys in the defaults
-                    print u"{0} v{1}: Saving {2} new {3}".format(PLUGIN_NAME, PLUGIN_VERSION, len(newkeys), u"key" if len(newkeys)==1 else u"keys")
+                    print(u"{0} v{1}: Saving {2} new {3}".format(PLUGIN_NAME, PLUGIN_VERSION, len(newkeys), u"key" if len(newkeys)==1 else u"keys"))
                     for keyvalue in newkeys.values():
                         dedrmprefs.addnamedvaluetoprefs('kindlekeys','default_key',keyvalue)
                     dedrmprefs.writeprefs()
-                except Exception, e:
+                except Exception as e:
                     pass
             if not decoded:
                 #if you reached here then no luck raise and exception
-                print u"{0} v{1}: Ultimately failed to decrypt after {2:.1f} seconds. Read the FAQs at Harper's repository: https://github.com/apprenticeharper/DeDRM_tools/blob/master/FAQs.md".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime)
+                print(u"{0} v{1}: Ultimately failed to decrypt after {2:.1f} seconds. Read the FAQs at Harper's repository: https://github.com/apprenticeharper/DeDRM_tools/blob/master/FAQs.md".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
                 raise DeDRMError(u"{0} v{1}: Ultimately failed to decrypt after {2:.1f} seconds. Read the FAQs at Harper's repository: https://github.com/apprenticeharper/DeDRM_tools/blob/master/FAQs.md".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
 
         of = self.temporary_file(book.getBookExtension())
@@ -590,7 +593,7 @@ class DeDRM(FileTypePlugin):
         # Attempt to decrypt epub with each encryption key (generated or provided).
         for keyname, userkey in dedrmprefs['ereaderkeys'].items():
             keyname_masked = u"".join((u'X' if (x.isdigit()) else x) for x in keyname)
-            print u"{0} v{1}: Trying Encryption key {2:s}".format(PLUGIN_NAME, PLUGIN_VERSION, keyname_masked)
+            print(u"{0} v{1}: Trying Encryption key {2:s}".format(PLUGIN_NAME, PLUGIN_VERSION, keyname_masked))
             of = self.temporary_file(u".pmlz")
 
             # Give the userkey, ebook and TemporaryPersistent file to the decryption function.
@@ -601,12 +604,12 @@ class DeDRM(FileTypePlugin):
             # Decryption was successful return the modified PersistentTemporary
             # file to Calibre's import process.
             if  result == 0:
-                print u"{0} v{1}: Successfully decrypted with key {2:s} after {3:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,keyname_masked,time.time()-self.starttime)
+                print(u"{0} v{1}: Successfully decrypted with key {2:s} after {3:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,keyname_masked,time.time()-self.starttime))
                 return of.name
 
-            print u"{0} v{1}: Failed to decrypt with key {2:s} after {3:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,keyname_masked,time.time()-self.starttime)
+            print(u"{0} v{1}: Failed to decrypt with key {2:s} after {3:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,keyname_masked,time.time()-self.starttime))
 
-        print u"{0} v{1}: Ultimately failed to decrypt after {2:.1f} seconds. Read the FAQs at Harper's repository: https://github.com/apprenticeharper/DeDRM_tools/blob/master/FAQs.md".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime)
+        print(u"{0} v{1}: Ultimately failed to decrypt after {2:.1f} seconds. Read the FAQs at Harper's repository: https://github.com/apprenticeharper/DeDRM_tools/blob/master/FAQs.md".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
         raise DeDRMError(u"{0} v{1}: Ultimately failed to decrypt after {2:.1f} seconds. Read the FAQs at Harper's repository: https://github.com/apprenticeharper/DeDRM_tools/blob/master/FAQs.md".format(PLUGIN_NAME, PLUGIN_VERSION, time.time()-self.starttime))
 
 
@@ -616,7 +619,7 @@ class DeDRM(FileTypePlugin):
         sys.stdout=SafeUnbuffered(sys.stdout)
         sys.stderr=SafeUnbuffered(sys.stderr)
 
-        print u"{0} v{1}: Trying to decrypt {2}".format(PLUGIN_NAME, PLUGIN_VERSION, os.path.basename(path_to_ebook))
+        print(u"{0} v{1}: Trying to decrypt {2}".format(PLUGIN_NAME, PLUGIN_VERSION, os.path.basename(path_to_ebook)))
         self.starttime = time.time()
 
         booktype = os.path.splitext(path_to_ebook)[1].lower()[1:]
@@ -635,9 +638,9 @@ class DeDRM(FileTypePlugin):
             # Adobe Adept or B&N ePub
             decrypted_ebook = self.ePubDecrypt(path_to_ebook)
         else:
-            print u"Unknown booktype {0}. Passing back to calibre unchanged".format(booktype)
+            print(u"Unknown booktype {0}. Passing back to calibre unchanged".format(booktype))
             return path_to_ebook
-        print u"{0} v{1}: Finished after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime)
+        print(u"{0} v{1}: Finished after {2:.1f} seconds".format(PLUGIN_NAME, PLUGIN_VERSION,time.time()-self.starttime))
         return decrypted_ebook
 
     def is_customizable(self):

--- a/DeDRM_plugin/adobekey.py
+++ b/DeDRM_plugin/adobekey.py
@@ -555,7 +555,7 @@ def gui_main():
     try:
         import six.moves.tkinter
         import six.moves.tkinter_constants
-        import six.moves.tkinter_messagebox
+        from six.moves import tkinter, tkinter_constants, tkinter_messagebox
         import traceback
     except:
         return cli_main()

--- a/DeDRM_plugin/adobekey.py
+++ b/DeDRM_plugin/adobekey.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+from __future__ import absolute_import
 
 # adobekey.pyw, version 6.0
 # Copyright © 2009-2010 i♥cabbages
@@ -51,12 +53,12 @@
 """
 Retrieve Adobe ADEPT user key.
 """
-from __future__ import print_function
-
 __license__ = 'GPL v3'
 __version__ = '6.0'
 
 import sys, os, struct, getopt
+import six
+
 
 # Wrap a stream so that output gets flushed immediately
 # and also make sure that any unicode strings get
@@ -68,7 +70,7 @@ class SafeUnbuffered:
         if self.encoding == None:
             self.encoding = "utf-8"
     def write(self, data):
-        if isinstance(data,unicode):
+        if isinstance(data,six.text_type):
             data = data.encode(self.encoding,"replace")
         self.stream.write(data)
         self.stream.flush()
@@ -109,7 +111,7 @@ def unicode_argv():
             # Remove Python executable and commands if present
             start = argc.value - len(sys.argv)
             return [argv[i] for i in
-                    xrange(start, argc.value)]
+                    range(start, argc.value)]
         # if we don't have any arguments at all, just pass back script name
         # this should never happen
         return [u"adobekey.py"]
@@ -117,7 +119,7 @@ def unicode_argv():
         argvencoding = sys.stdin.encoding
         if argvencoding == None:
             argvencoding = "utf-8"
-        return [arg if (type(arg) == unicode) else unicode(arg,argvencoding) for arg in sys.argv]
+        return [arg if (type(arg) == six.text_type) else six.text_type(arg,argvencoding) for arg in sys.argv]
 
 class ADEPTError(Exception):
     pass
@@ -129,7 +131,7 @@ if iswindows:
         c_long, c_ulong
 
     from ctypes.wintypes import LPVOID, DWORD, BOOL
-    import _winreg as winreg
+    import six.moves.winreg as winreg
 
     def _load_crypto_libcrypto():
         from ctypes.util import find_library
@@ -382,7 +384,7 @@ if iswindows:
             plkroot = winreg.OpenKey(cuser, PRIVATE_LICENCE_KEY_PATH)
         except WindowsError:
             raise ADEPTError("Could not locate ADE activation")
-        for i in xrange(0, 16):
+        for i in range(0, 16):
             try:
                 plkparent = winreg.OpenKey(plkroot, "%04d" % (i,))
             except WindowsError:
@@ -390,7 +392,7 @@ if iswindows:
             ktype = winreg.QueryValueEx(plkparent, None)[0]
             if ktype != 'credentials':
                 continue
-            for j in xrange(0, 16):
+            for j in range(0, 16):
                 try:
                     plkkey = winreg.OpenKey(plkparent, "%04d" % (j,))
                 except WindowsError:
@@ -430,7 +432,7 @@ elif isosx:
         reslst = out1.split('\n')
         cnt = len(reslst)
         ActDatPath = "activation.dat"
-        for j in xrange(cnt):
+        for j in range(cnt):
             resline = reslst[j]
             pp = resline.find('activation.dat')
             if pp >= 0:
@@ -463,7 +465,7 @@ def getkey(outpath):
     if len(keys) > 0:
         if not os.path.isdir(outpath):
             outfile = outpath
-            with file(outfile, 'wb') as keyfileout:
+            with open(outfile, 'wb') as keyfileout:
                 keyfileout.write(keys[0])
             print(u"Saved a key to {0}".format(outfile))
         else:
@@ -474,7 +476,7 @@ def getkey(outpath):
                     outfile = os.path.join(outpath,u"adobekey_{0:d}.der".format(keycount))
                     if not os.path.exists(outfile):
                         break
-                with file(outfile, 'wb') as keyfileout:
+                with open(outfile, 'wb') as keyfileout:
                     keyfileout.write(key)
                 print(u"Saved a key to {0}".format(outfile))
         return True
@@ -496,7 +498,7 @@ def cli_main():
 
     try:
         opts, args = getopt.getopt(argv[1:], "h")
-    except getopt.GetoptError, err:
+    except getopt.GetoptError as err:
         print(u"Error in options or arguments: {0}".format(err.args[0]))
         usage(progname)
         sys.exit(2)
@@ -547,27 +549,27 @@ def cli_main():
 
 def gui_main():
     try:
-        import Tkinter
-        import Tkconstants
-        import tkMessageBox
+        import six.moves.tkinter
+        import six.moves.tkinter_constants
+        import six.moves.tkinter_messagebox
         import traceback
     except:
         return cli_main()
 
-    class ExceptionDialog(Tkinter.Frame):
+    class ExceptionDialog(six.moves.tkinter.Frame):
         def __init__(self, root, text):
-            Tkinter.Frame.__init__(self, root, border=5)
-            label = Tkinter.Label(self, text=u"Unexpected error:",
-                                  anchor=Tkconstants.W, justify=Tkconstants.LEFT)
-            label.pack(fill=Tkconstants.X, expand=0)
-            self.text = Tkinter.Text(self)
-            self.text.pack(fill=Tkconstants.BOTH, expand=1)
+            six.moves.tkinter.Frame.__init__(self, root, border=5)
+            label = six.moves.tkinter.Label(self, text=u"Unexpected error:",
+                                  anchor=six.moves.tkinter_constants.W, justify=six.moves.tkinter_constants.LEFT)
+            label.pack(fill=six.moves.tkinter_constants.X, expand=0)
+            self.text = six.moves.tkinter.Text(self)
+            self.text.pack(fill=six.moves.tkinter_constants.BOTH, expand=1)
 
-            self.text.insert(Tkconstants.END, text)
+            self.text.insert(six.moves.tkinter_constants.END, text)
 
 
     argv=unicode_argv()
-    root = Tkinter.Tk()
+    root = six.moves.tkinter.Tk()
     root.withdraw()
     progpath, progname = os.path.split(argv[0])
     success = False
@@ -581,17 +583,17 @@ def gui_main():
                 if not os.path.exists(outfile):
                     break
 
-            with file(outfile, 'wb') as keyfileout:
+            with open(outfile, 'wb') as keyfileout:
                 keyfileout.write(key)
             success = True
-            tkMessageBox.showinfo(progname, u"Key successfully retrieved to {0}".format(outfile))
-    except ADEPTError, e:
-        tkMessageBox.showerror(progname, u"Error: {0}".format(str(e)))
+            six.moves.tkinter_messagebox.showinfo(progname, u"Key successfully retrieved to {0}".format(outfile))
+    except ADEPTError as e:
+        six.moves.tkinter_messagebox.showerror(progname, u"Error: {0}".format(str(e)))
     except Exception:
         root.wm_state('normal')
         root.title(progname)
         text = traceback.format_exc()
-        ExceptionDialog(root, text).pack(fill=Tkconstants.BOTH, expand=1)
+        ExceptionDialog(root, text).pack(fill=six.moves.tkinter_constants.BOTH, expand=1)
         root.mainloop()
     if not success:
         return 1

--- a/DeDRM_plugin/adobekey.py
+++ b/DeDRM_plugin/adobekey.py
@@ -125,7 +125,7 @@ def unicode_argv():
         argvencoding = sys.stdin.encoding
         if argvencoding == None:
             argvencoding = "utf-8"
-        return [arg if (type(arg) == six.text_type) else six.text_type(arg,argvencoding) for arg in sys.argv]
+        return [arg if isinstance(arg, six.text_type) else six.text_type(arg, argvencoding) for arg in sys.argv]
 
 class ADEPTError(Exception):
     pass

--- a/DeDRM_plugin/adobekey.py
+++ b/DeDRM_plugin/adobekey.py
@@ -551,27 +551,25 @@ def cli_main():
 
 def gui_main():
     try:
-        import six.moves.tkinter
-        import six.moves.tkinter_constants
         from six.moves import tkinter, tkinter_constants, tkinter_messagebox
         import traceback
     except:
         return cli_main()
 
-    class ExceptionDialog(six.moves.tkinter.Frame):
+    class ExceptionDialog(tkinter.Frame):
         def __init__(self, root, text):
-            six.moves.tkinter.Frame.__init__(self, root, border=5)
-            label = six.moves.tkinter.Label(self, text=u"Unexpected error:",
-                                  anchor=six.moves.tkinter_constants.W, justify=six.moves.tkinter_constants.LEFT)
-            label.pack(fill=six.moves.tkinter_constants.X, expand=0)
-            self.text = six.moves.tkinter.Text(self)
-            self.text.pack(fill=six.moves.tkinter_constants.BOTH, expand=1)
+            tkinter.Frame.__init__(self, root, border=5)
+            label = tkinter.Label(self, text=u"Unexpected error:",
+                                  anchor=tkinter_constants.W, justify=tkinter_constants.LEFT)
+            label.pack(fill=tkinter_constants.X, expand=0)
+            self.text = tkinter.Text(self)
+            self.text.pack(fill=tkinter_constants.BOTH, expand=1)
 
-            self.text.insert(six.moves.tkinter_constants.END, text)
+            self.text.insert(tkinter_constants.END, text)
 
 
     argv=unicode_argv()
-    root = six.moves.tkinter.Tk()
+    root = tkinter.Tk()
     root.withdraw()
     progpath, progname = os.path.split(argv[0])
     success = False
@@ -588,14 +586,14 @@ def gui_main():
             with open(outfile, 'wb') as keyfileout:
                 keyfileout.write(key)
             success = True
-            six.moves.tkinter_messagebox.showinfo(progname, u"Key successfully retrieved to {0}".format(outfile))
+            tkinter_messagebox.showinfo(progname, u"Key successfully retrieved to {0}".format(outfile))
     except ADEPTError as e:
-        six.moves.tkinter_messagebox.showerror(progname, u"Error: {0}".format(str(e)))
+        tkinter_messagebox.showerror(progname, u"Error: {0}".format(str(e)))
     except Exception:
         root.wm_state('normal')
         root.title(progname)
         text = traceback.format_exc()
-        ExceptionDialog(root, text).pack(fill=six.moves.tkinter_constants.BOTH, expand=1)
+        ExceptionDialog(root, text).pack(fill=tkinter_constants.BOTH, expand=1)
         root.mainloop()
     if not success:
         return 1

--- a/DeDRM_plugin/adobekey.py
+++ b/DeDRM_plugin/adobekey.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 
 # adobekey.pyw, version 6.0
 # Copyright © 2009-2010 i♥cabbages

--- a/DeDRM_plugin/adobekey.py
+++ b/DeDRM_plugin/adobekey.py
@@ -72,8 +72,13 @@ class SafeUnbuffered:
     def write(self, data):
         if isinstance(data,six.text_type):
             data = data.encode(self.encoding,"replace")
-        self.stream.write(data)
-        self.stream.flush()
+        if six.PY3:
+            self.stream.buffer.write(data)
+            self.stream.buffer.flush()
+        else:
+            self.stream.write(data)
+            self.stream.flush()
+
     def __getattr__(self, attr):
         return getattr(self.stream, attr)
 

--- a/DeDRM_plugin/adobekey.py
+++ b/DeDRM_plugin/adobekey.py
@@ -122,7 +122,7 @@ def unicode_argv():
         # this should never happen
         return [u"adobekey.py"]
     else:
-        argvencoding = sys.stdin.encoding
+        argvencoding = sys.stdin.encoding or "utf-8"
         if argvencoding == None:
             argvencoding = "utf-8"
         return [arg if isinstance(arg, six.text_type) else six.text_type(arg, argvencoding) for arg in sys.argv]

--- a/DeDRM_plugin/adobekey.py
+++ b/DeDRM_plugin/adobekey.py
@@ -520,9 +520,7 @@ def cli_main():
 
     if len(args) == 1:
         # save to the specified file or directory
-        outpath = args[0]
-        if not os.path.isabs(outpath):
-           outpath = os.path.abspath(outpath)
+        outpath = os.path.abspath(args[0])
     else:
         # save to the same directory as the script
         outpath = os.path.dirname(argv[0])

--- a/DeDRM_plugin/adobekey.py
+++ b/DeDRM_plugin/adobekey.py
@@ -123,8 +123,6 @@ def unicode_argv():
         return [u"adobekey.py"]
     else:
         argvencoding = sys.stdin.encoding or "utf-8"
-        if argvencoding == None:
-            argvencoding = "utf-8"
         return [arg if isinstance(arg, six.text_type) else six.text_type(arg, argvencoding) for arg in sys.argv]
 
 class ADEPTError(Exception):

--- a/DeDRM_plugin/androidkindlekey.py
+++ b/DeDRM_plugin/androidkindlekey.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 
 # androidkindlekey.py
 # Copyright © 2013-15 by Thom and Apprentice Harper

--- a/DeDRM_plugin/config.py
+++ b/DeDRM_plugin/config.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 from __future__ import print_function
 
 __license__ = 'GPL v3'

--- a/DeDRM_plugin/encodebase64.py
+++ b/DeDRM_plugin/encodebase64.py
@@ -14,7 +14,6 @@
 Provide base64 encoding.
 """
 
-from __future__ import with_statement
 from __future__ import print_function
 
 __license__ = 'GPL v3'

--- a/DeDRM_plugin/epubtest.py
+++ b/DeDRM_plugin/epubtest.py
@@ -44,7 +44,6 @@
 # It's still polite to give attribution if you do reuse this code.
 #
 
-from __future__ import with_statement
 from __future__ import print_function
 
 __version__ = '1.01'

--- a/DeDRM_plugin/ignobleepub.py
+++ b/DeDRM_plugin/ignobleepub.py
@@ -113,7 +113,7 @@ def unicode_argv():
         argvencoding = sys.stdin.encoding
         if argvencoding == None:
             argvencoding = "utf-8"
-        return [arg if (type(arg) == six.text_type) else six.text_type(arg,argvencoding) for arg in sys.argv]
+        return [arg if isinstance(arg, six.text_type) else six.text_type(arg,argvencoding) for arg in sys.argv]
 
 
 class IGNOBLEError(Exception):

--- a/DeDRM_plugin/ignobleepub.py
+++ b/DeDRM_plugin/ignobleepub.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import with_statement
-import six
-from six.moves import range
+from __future__ import print_function
+from __future__ import absolute_import
 
 # ignobleepub.pyw, version 4.1
 # Copyright © 2009-2010 by i♥cabbages
@@ -43,9 +43,7 @@ from six.moves import range
 """
 Decrypt Barnes & Noble encrypted ePub books.
 """
-from __future__ import print_function
 
-from __future__ import absolute_import
 __license__ = 'GPL v3'
 __version__ = "4.1"
 

--- a/DeDRM_plugin/ignobleepub.py
+++ b/DeDRM_plugin/ignobleepub.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 from __future__ import print_function
 from __future__ import absolute_import
 

--- a/DeDRM_plugin/ignobleepub.py
+++ b/DeDRM_plugin/ignobleepub.py
@@ -51,6 +51,7 @@ import os
 import traceback
 import zlib
 import zipfile
+import six
 from zipfile import ZipInfo, ZipFile, ZIP_STORED, ZIP_DEFLATED
 from contextlib import closing
 import xml.etree.ElementTree as etree

--- a/DeDRM_plugin/ignobleepub.py
+++ b/DeDRM_plugin/ignobleepub.py
@@ -338,79 +338,76 @@ def cli_main():
 
 def gui_main():
     try:
-        import six.moves.tkinter
-        import six.moves.tkinter_constants
-        import six.moves.tkinter_filedialog
-        import six.moves.tkinter_messagebox
+        from six.moves import tkinter, tkinter_constants, tkinter_filedialog, tkinter_messagebox
         import traceback
-    except:
+    except ImportError:
         return cli_main()
 
-    class DecryptionDialog(six.moves.tkinter.Frame):
+    class DecryptionDialog(tkinter.Frame):
         def __init__(self, root):
-            six.moves.tkinter.Frame.__init__(self, root, border=5)
-            self.status = six.moves.tkinter.Label(self, text=u"Select files for decryption")
-            self.status.pack(fill=six.moves.tkinter_constants.X, expand=1)
-            body = six.moves.tkinter.Frame(self)
-            body.pack(fill=six.moves.tkinter_constants.X, expand=1)
-            sticky = six.moves.tkinter_constants.E + six.moves.tkinter_constants.W
+            tkinter.Frame.__init__(self, root, border=5)
+            self.status = tkinter.Label(self, text=u"Select files for decryption")
+            self.status.pack(fill=tkinter_constants.X, expand=1)
+            body = tkinter.Frame(self)
+            body.pack(fill=tkinter_constants.X, expand=1)
+            sticky = tkinter_constants.E + tkinter_constants.W
             body.grid_columnconfigure(1, weight=2)
-            six.moves.tkinter.Label(body, text=u"Key file").grid(row=0)
-            self.keypath = six.moves.tkinter.Entry(body, width=30)
+            tkinter.Label(body, text=u"Key file").grid(row=0)
+            self.keypath = tkinter.Entry(body, width=30)
             self.keypath.grid(row=0, column=1, sticky=sticky)
             if os.path.exists(u"bnepubkey.b64"):
                 self.keypath.insert(0, u"bnepubkey.b64")
-            button = six.moves.tkinter.Button(body, text=u"...", command=self.get_keypath)
+            button = tkinter.Button(body, text=u"...", command=self.get_keypath)
             button.grid(row=0, column=2)
-            six.moves.tkinter.Label(body, text=u"Input file").grid(row=1)
-            self.inpath = six.moves.tkinter.Entry(body, width=30)
+            tkinter.Label(body, text=u"Input file").grid(row=1)
+            self.inpath = tkinter.Entry(body, width=30)
             self.inpath.grid(row=1, column=1, sticky=sticky)
-            button = six.moves.tkinter.Button(body, text=u"...", command=self.get_inpath)
+            button = tkinter.Button(body, text=u"...", command=self.get_inpath)
             button.grid(row=1, column=2)
-            six.moves.tkinter.Label(body, text=u"Output file").grid(row=2)
-            self.outpath = six.moves.tkinter.Entry(body, width=30)
+            tkinter.Label(body, text=u"Output file").grid(row=2)
+            self.outpath = tkinter.Entry(body, width=30)
             self.outpath.grid(row=2, column=1, sticky=sticky)
-            button = six.moves.tkinter.Button(body, text=u"...", command=self.get_outpath)
+            button = tkinter.Button(body, text=u"...", command=self.get_outpath)
             button.grid(row=2, column=2)
-            buttons = six.moves.tkinter.Frame(self)
+            buttons = tkinter.Frame(self)
             buttons.pack()
-            botton = six.moves.tkinter.Button(
+            botton = tkinter.Button(
                 buttons, text=u"Decrypt", width=10, command=self.decrypt)
-            botton.pack(side=six.moves.tkinter_constants.LEFT)
-            six.moves.tkinter.Frame(buttons, width=10).pack(side=six.moves.tkinter_constants.LEFT)
-            button = six.moves.tkinter.Button(
+            botton.pack(side=tkinter_constants.LEFT)
+            tkinter.Frame(buttons, width=10).pack(side=tkinter_constants.LEFT)
+            button = tkinter.Button(
                 buttons, text=u"Quit", width=10, command=self.quit)
-            button.pack(side=six.moves.tkinter_constants.RIGHT)
+            button.pack(side=tkinter_constants.RIGHT)
 
         def get_keypath(self):
-            keypath = six.moves.tkinter_filedialog.askopenfilename(
+            keypath = tkinter_filedialog.askopenfilename(
                 parent=None, title=u"Select Barnes & Noble \'.b64\' key file",
                 defaultextension=u".b64",
                 filetypes=[('base64-encoded files', '.b64'),
                            ('All Files', '.*')])
             if keypath:
                 keypath = os.path.normpath(keypath)
-                self.keypath.delete(0, six.moves.tkinter_constants.END)
+                self.keypath.delete(0, tkinter_constants.END)
                 self.keypath.insert(0, keypath)
             return
 
         def get_inpath(self):
-            inpath = six.moves.tkinter_filedialog.askopenfilename(
+            inpath = tkinter_filedialog.askopenfilename(
                 parent=None, title=u"Select B&N-encrypted ePub file to decrypt",
                 defaultextension=u".epub", filetypes=[('ePub files', '.epub')])
             if inpath:
                 inpath = os.path.normpath(inpath)
-                self.inpath.delete(0, six.moves.tkinter_constants.END)
+                self.inpath.delete(0, tkinter_constants.END)
                 self.inpath.insert(0, inpath)
             return
 
         def get_outpath(self):
-            outpath = six.moves.tkinter_filedialog.asksaveasfilename(
+            outpath = tkinter_filedialog.asksaveasfilename(
                 parent=None, title=u"Select unencrypted ePub file to produce",
                 defaultextension=u".epub", filetypes=[('ePub files', '.epub')])
             if outpath:
                 outpath = os.path.normpath(outpath)
-                self.outpath.delete(0, six.moves.tkinter_constants.END)
+                self.outpath.delete(0, tkinter_constants.END)
                 self.outpath.insert(0, outpath)
             return
 
@@ -442,11 +439,11 @@ def gui_main():
             else:
                 self.status['text'] = u"The was an error decrypting the file."
 
-    root = six.moves.tkinter.Tk()
+    root = tkinter.Tk()
     root.title(u"Barnes & Noble ePub Decrypter v.{0}".format(__version__))
     root.resizable(True, False)
     root.minsize(300, 0)
-    DecryptionDialog(root).pack(fill=six.moves.tkinter_constants.X, expand=1)
+    DecryptionDialog(root).pack(fill=tkinter_constants.X, expand=1)
     root.mainloop()
     return 0
 

--- a/DeDRM_plugin/ignobleepub.py
+++ b/DeDRM_plugin/ignobleepub.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import with_statement
+import six
+from six.moves import range
 
 # ignobleepub.pyw, version 4.1
 # Copyright © 2009-2010 by i♥cabbages
@@ -43,6 +45,7 @@ Decrypt Barnes & Noble encrypted ePub books.
 """
 from __future__ import print_function
 
+from __future__ import absolute_import
 __license__ = 'GPL v3'
 __version__ = "4.1"
 
@@ -65,7 +68,7 @@ class SafeUnbuffered:
         if self.encoding == None:
             self.encoding = "utf-8"
     def write(self, data):
-        if isinstance(data,unicode):
+        if isinstance(data,six.text_type):
             data = data.encode(self.encoding,"replace")
         self.stream.write(data)
         self.stream.flush()
@@ -106,13 +109,13 @@ def unicode_argv():
             # Remove Python executable and commands if present
             start = argc.value - len(sys.argv)
             return [argv[i] for i in
-                    xrange(start, argc.value)]
+                    range(start, argc.value)]
         return [u"ineptepub.py"]
     else:
         argvencoding = sys.stdin.encoding
         if argvencoding == None:
             argvencoding = "utf-8"
-        return [arg if (type(arg) == unicode) else unicode(arg,argvencoding) for arg in sys.argv]
+        return [arg if (type(arg) == six.text_type) else six.text_type(arg,argvencoding) for arg in sys.argv]
 
 
 class IGNOBLEError(Exception):
@@ -338,79 +341,79 @@ def cli_main():
 
 def gui_main():
     try:
-        import Tkinter
-        import Tkconstants
-        import tkFileDialog
-        import tkMessageBox
+        import six.moves.tkinter
+        import six.moves.tkinter_constants
+        import six.moves.tkinter_filedialog
+        import six.moves.tkinter_messagebox
         import traceback
     except:
         return cli_main()
 
-    class DecryptionDialog(Tkinter.Frame):
+    class DecryptionDialog(six.moves.tkinter.Frame):
         def __init__(self, root):
-            Tkinter.Frame.__init__(self, root, border=5)
-            self.status = Tkinter.Label(self, text=u"Select files for decryption")
-            self.status.pack(fill=Tkconstants.X, expand=1)
-            body = Tkinter.Frame(self)
-            body.pack(fill=Tkconstants.X, expand=1)
-            sticky = Tkconstants.E + Tkconstants.W
+            six.moves.tkinter.Frame.__init__(self, root, border=5)
+            self.status = six.moves.tkinter.Label(self, text=u"Select files for decryption")
+            self.status.pack(fill=six.moves.tkinter_constants.X, expand=1)
+            body = six.moves.tkinter.Frame(self)
+            body.pack(fill=six.moves.tkinter_constants.X, expand=1)
+            sticky = six.moves.tkinter_constants.E + six.moves.tkinter_constants.W
             body.grid_columnconfigure(1, weight=2)
-            Tkinter.Label(body, text=u"Key file").grid(row=0)
-            self.keypath = Tkinter.Entry(body, width=30)
+            six.moves.tkinter.Label(body, text=u"Key file").grid(row=0)
+            self.keypath = six.moves.tkinter.Entry(body, width=30)
             self.keypath.grid(row=0, column=1, sticky=sticky)
             if os.path.exists(u"bnepubkey.b64"):
                 self.keypath.insert(0, u"bnepubkey.b64")
-            button = Tkinter.Button(body, text=u"...", command=self.get_keypath)
+            button = six.moves.tkinter.Button(body, text=u"...", command=self.get_keypath)
             button.grid(row=0, column=2)
-            Tkinter.Label(body, text=u"Input file").grid(row=1)
-            self.inpath = Tkinter.Entry(body, width=30)
+            six.moves.tkinter.Label(body, text=u"Input file").grid(row=1)
+            self.inpath = six.moves.tkinter.Entry(body, width=30)
             self.inpath.grid(row=1, column=1, sticky=sticky)
-            button = Tkinter.Button(body, text=u"...", command=self.get_inpath)
+            button = six.moves.tkinter.Button(body, text=u"...", command=self.get_inpath)
             button.grid(row=1, column=2)
-            Tkinter.Label(body, text=u"Output file").grid(row=2)
-            self.outpath = Tkinter.Entry(body, width=30)
+            six.moves.tkinter.Label(body, text=u"Output file").grid(row=2)
+            self.outpath = six.moves.tkinter.Entry(body, width=30)
             self.outpath.grid(row=2, column=1, sticky=sticky)
-            button = Tkinter.Button(body, text=u"...", command=self.get_outpath)
+            button = six.moves.tkinter.Button(body, text=u"...", command=self.get_outpath)
             button.grid(row=2, column=2)
-            buttons = Tkinter.Frame(self)
+            buttons = six.moves.tkinter.Frame(self)
             buttons.pack()
-            botton = Tkinter.Button(
+            botton = six.moves.tkinter.Button(
                 buttons, text=u"Decrypt", width=10, command=self.decrypt)
-            botton.pack(side=Tkconstants.LEFT)
-            Tkinter.Frame(buttons, width=10).pack(side=Tkconstants.LEFT)
-            button = Tkinter.Button(
+            botton.pack(side=six.moves.tkinter_constants.LEFT)
+            six.moves.tkinter.Frame(buttons, width=10).pack(side=six.moves.tkinter_constants.LEFT)
+            button = six.moves.tkinter.Button(
                 buttons, text=u"Quit", width=10, command=self.quit)
-            button.pack(side=Tkconstants.RIGHT)
+            button.pack(side=six.moves.tkinter_constants.RIGHT)
 
         def get_keypath(self):
-            keypath = tkFileDialog.askopenfilename(
+            keypath = six.moves.tkinter_filedialog.askopenfilename(
                 parent=None, title=u"Select Barnes & Noble \'.b64\' key file",
                 defaultextension=u".b64",
                 filetypes=[('base64-encoded files', '.b64'),
                            ('All Files', '.*')])
             if keypath:
                 keypath = os.path.normpath(keypath)
-                self.keypath.delete(0, Tkconstants.END)
+                self.keypath.delete(0, six.moves.tkinter_constants.END)
                 self.keypath.insert(0, keypath)
             return
 
         def get_inpath(self):
-            inpath = tkFileDialog.askopenfilename(
+            inpath = six.moves.tkinter_filedialog.askopenfilename(
                 parent=None, title=u"Select B&N-encrypted ePub file to decrypt",
                 defaultextension=u".epub", filetypes=[('ePub files', '.epub')])
             if inpath:
                 inpath = os.path.normpath(inpath)
-                self.inpath.delete(0, Tkconstants.END)
+                self.inpath.delete(0, six.moves.tkinter_constants.END)
                 self.inpath.insert(0, inpath)
             return
 
         def get_outpath(self):
-            outpath = tkFileDialog.asksaveasfilename(
+            outpath = six.moves.tkinter_filedialog.asksaveasfilename(
                 parent=None, title=u"Select unencrypted ePub file to produce",
                 defaultextension=u".epub", filetypes=[('ePub files', '.epub')])
             if outpath:
                 outpath = os.path.normpath(outpath)
-                self.outpath.delete(0, Tkconstants.END)
+                self.outpath.delete(0, six.moves.tkinter_constants.END)
                 self.outpath.insert(0, outpath)
             return
 
@@ -434,7 +437,7 @@ def gui_main():
             self.status['text'] = u"Decrypting..."
             try:
                 decrypt_status = decryptBook(userkey, inpath, outpath)
-            except Exception, e:
+            except Exception as e:
                 self.status['text'] = u"Error: {0}".format(e.args[0])
                 return
             if decrypt_status == 0:
@@ -442,11 +445,11 @@ def gui_main():
             else:
                 self.status['text'] = u"The was an error decrypting the file."
 
-    root = Tkinter.Tk()
+    root = six.moves.tkinter.Tk()
     root.title(u"Barnes & Noble ePub Decrypter v.{0}".format(__version__))
     root.resizable(True, False)
     root.minsize(300, 0)
-    DecryptionDialog(root).pack(fill=Tkconstants.X, expand=1)
+    DecryptionDialog(root).pack(fill=six.moves.tkinter_constants.X, expand=1)
     root.mainloop()
     return 0
 

--- a/DeDRM_plugin/ignoblekey.py
+++ b/DeDRM_plugin/ignoblekey.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 
 # ignoblekey.py
 # Copyright © 2015 Apprentice Alf and Apprentice Harper

--- a/DeDRM_plugin/ignoblekeyfetch.py
+++ b/DeDRM_plugin/ignoblekeyfetch.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 
 # ignoblekeyfetch.pyw, version 1.1
 # Copyright © 2015 Apprentice Harper

--- a/DeDRM_plugin/ignoblekeygen.py
+++ b/DeDRM_plugin/ignoblekeygen.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 
 # ignoblekeygen.pyw, version 2.5
 # Copyright © 2009-2010 i♥cabbages

--- a/DeDRM_plugin/ignoblepdf.py
+++ b/DeDRM_plugin/ignoblepdf.py
@@ -1,7 +1,6 @@
 #! /usr/bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 
 # ignoblepdf.py
 # Copyright © 2009-2020 by Apprentice Harper et al.

--- a/DeDRM_plugin/ineptepub.py
+++ b/DeDRM_plugin/ineptepub.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 from __future__ import absolute_import
 from __future__ import print_function
 

--- a/DeDRM_plugin/ineptpdf.py
+++ b/DeDRM_plugin/ineptpdf.py
@@ -1,7 +1,6 @@
 #! /usr/bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 
 # ineptpdf.py
 # Copyright © 2009-2017 by Apprentice Harper et al.

--- a/DeDRM_plugin/ion.py
+++ b/DeDRM_plugin/ion.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 
 # ion.py
 # Copyright © 2013-2020 Apprentice Harper et al.

--- a/DeDRM_plugin/k4mobidedrm.py
+++ b/DeDRM_plugin/k4mobidedrm.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 
 # k4mobidedrm.py
 # Copyright © 2008-2019 by Apprentice Harper et al.

--- a/DeDRM_plugin/kfxdedrm.py
+++ b/DeDRM_plugin/kfxdedrm.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 from __future__ import print_function
 
 # Engine to remove drm from Kindle KFX ebooks

--- a/DeDRM_plugin/kgenpids.py
+++ b/DeDRM_plugin/kgenpids.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 from __future__ import print_function
 
 # kgenpids.py

--- a/DeDRM_plugin/kindlekey.py
+++ b/DeDRM_plugin/kindlekey.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 
 # kindlekey.py
 # Copyright © 2008-2020 Apprentice Harper et al.

--- a/DeDRM_plugin/prefs.py
+++ b/DeDRM_plugin/prefs.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # vim:fileencoding=UTF-8:ts=4:sw=4:sta:et:sts=4:ai
 
-from __future__ import with_statement
 from __future__ import absolute_import
 from __future__ import print_function
 __license__ = 'GPL v3'

--- a/DeDRM_plugin/prefs.py
+++ b/DeDRM_plugin/prefs.py
@@ -2,6 +2,8 @@
 # vim:fileencoding=UTF-8:ts=4:sw=4:sta:et:sts=4:ai
 
 from __future__ import with_statement
+from __future__ import absolute_import
+from __future__ import print_function
 __license__ = 'GPL v3'
 
 # Standard Python modules.
@@ -61,7 +63,7 @@ class DeDRM_Prefs():
 
     def addnamedvaluetoprefs(self, prefkind, keyname, keyvalue):
         try:
-            if keyvalue not in self.dedrmprefs[prefkind].values():
+            if keyvalue not in list(self.dedrmprefs[prefkind].values()):
                 # ensure that the keyname is unique
                 # by adding a number (starting with 2) to the name if it is not
                 namecount = 1
@@ -101,9 +103,9 @@ def convertprefs(always = False):
                 keyname = u"{0}_{1}".format(name.strip(),ccn.strip()[-4:])
                 keyvalue = generate_key(name, ccn)
                 userkeys.append([keyname,keyvalue])
-            except Exception, e:
+            except Exception as e:
                 traceback.print_exc()
-                print e.args[0]
+                print(e.args[0])
                 pass
         return userkeys
 
@@ -118,9 +120,9 @@ def convertprefs(always = False):
                 keyname = u"{0}_{1}".format(name.strip(),cc.strip()[-4:])
                 keyvalue = getuser_key(name,cc).encode('hex')
                 userkeys.append([keyname,keyvalue])
-            except Exception, e:
+            except Exception as e:
                 traceback.print_exc()
-                print e.args[0]
+                print(e.args[0])
                 pass
         return userkeys
 
@@ -161,7 +163,7 @@ def convertprefs(always = False):
         return
 
 
-    print u"{0} v{1}: Importing configuration data from old DeDRM plugins".format(PLUGIN_NAME, PLUGIN_VERSION)
+    print(u"{0} v{1}: Importing configuration data from old DeDRM plugins".format(PLUGIN_NAME, PLUGIN_VERSION))
 
     IGNOBLEPLUGINNAME = "Ignoble Epub DeDRM"
     EREADERPLUGINNAME = "eReader PDB 2 PML"
@@ -177,7 +179,7 @@ def convertprefs(always = False):
     sc = config['plugin_customization']
     val = sc.pop(IGNOBLEPLUGINNAME, None)
     if val is not None:
-        print u"{0} v{1}: Converting old Ignoble plugin configuration string.".format(PLUGIN_NAME, PLUGIN_VERSION)
+        print(u"{0} v{1}: Converting old Ignoble plugin configuration string.".format(PLUGIN_NAME, PLUGIN_VERSION))
         priorkeycount = len(dedrmprefs['bandnkeys'])
         userkeys = parseIgnobleString(str(val))
         for keypair in userkeys:
@@ -185,7 +187,7 @@ def convertprefs(always = False):
             value = keypair[1]
             dedrmprefs.addnamedvaluetoprefs('bandnkeys', name, value)
         addedkeycount = len(dedrmprefs['bandnkeys'])-priorkeycount
-        print u"{0} v{1}: {2:d} Barnes and Noble {3} imported from old Ignoble plugin configuration string".format(PLUGIN_NAME, PLUGIN_VERSION, addedkeycount, u"key" if addedkeycount==1 else u"keys")
+        print(u"{0} v{1}: {2:d} Barnes and Noble {3} imported from old Ignoble plugin configuration string".format(PLUGIN_NAME, PLUGIN_VERSION, addedkeycount, u"key" if addedkeycount==1 else u"keys"))
     # Make the json write all the prefs to disk
     dedrmprefs.writeprefs(False)
 
@@ -193,7 +195,7 @@ def convertprefs(always = False):
     # old string to stored keys... get that personal data out of plain sight.
     val = sc.pop(EREADERPLUGINNAME, None)
     if val is not None:
-        print u"{0} v{1}: Converting old eReader plugin configuration string.".format(PLUGIN_NAME, PLUGIN_VERSION)
+        print(u"{0} v{1}: Converting old eReader plugin configuration string.".format(PLUGIN_NAME, PLUGIN_VERSION))
         priorkeycount = len(dedrmprefs['ereaderkeys'])
         userkeys = parseeReaderString(str(val))
         for keypair in userkeys:
@@ -201,14 +203,14 @@ def convertprefs(always = False):
             value = keypair[1]
             dedrmprefs.addnamedvaluetoprefs('ereaderkeys', name, value)
         addedkeycount = len(dedrmprefs['ereaderkeys'])-priorkeycount
-        print u"{0} v{1}: {2:d} eReader {3} imported from old eReader plugin configuration string".format(PLUGIN_NAME, PLUGIN_VERSION, addedkeycount, u"key" if addedkeycount==1 else u"keys")
+        print(u"{0} v{1}: {2:d} eReader {3} imported from old eReader plugin configuration string".format(PLUGIN_NAME, PLUGIN_VERSION, addedkeycount, u"key" if addedkeycount==1 else u"keys"))
     # Make the json write all the prefs to disk
     dedrmprefs.writeprefs(False)
 
     # get old Kindle plugin configuration string
     val = sc.pop(OLDKINDLEPLUGINNAME, None)
     if val is not None:
-        print u"{0} v{1}: Converting old Kindle plugin configuration string.".format(PLUGIN_NAME, PLUGIN_VERSION)
+        print(u"{0} v{1}: Converting old Kindle plugin configuration string.".format(PLUGIN_NAME, PLUGIN_VERSION))
         priorpidcount = len(dedrmprefs['pids'])
         priorserialcount = len(dedrmprefs['serials'])
         pids, serials = parseKindleString(val)
@@ -218,7 +220,7 @@ def convertprefs(always = False):
             dedrmprefs.addvaluetoprefs('serials',serial)
         addedpidcount = len(dedrmprefs['pids']) - priorpidcount
         addedserialcount = len(dedrmprefs['serials']) - priorserialcount
-        print u"{0} v{1}: {2:d} {3} and {4:d} {5} imported from old Kindle plugin configuration string.".format(PLUGIN_NAME, PLUGIN_VERSION, addedpidcount, u"PID" if addedpidcount==1 else u"PIDs", addedserialcount, u"serial number" if addedserialcount==1 else u"serial numbers")
+        print(u"{0} v{1}: {2:d} {3} and {4:d} {5} imported from old Kindle plugin configuration string.".format(PLUGIN_NAME, PLUGIN_VERSION, addedpidcount, u"PID" if addedpidcount==1 else u"PIDs", addedserialcount, u"serial number" if addedserialcount==1 else u"serial numbers"))
     # Make the json write all the prefs to disk
     dedrmprefs.writeprefs(False)
 
@@ -234,7 +236,7 @@ def convertprefs(always = False):
         dedrmprefs.addnamedvaluetoprefs('bandnkeys', name, value)
     addedkeycount = len(dedrmprefs['bandnkeys'])-priorkeycount
     if addedkeycount > 0:
-        print u"{0} v{1}: {2:d} Barnes and Noble {3} imported from config folder.".format(PLUGIN_NAME, PLUGIN_VERSION, addedkeycount, u"key file" if addedkeycount==1 else u"key files")
+        print(u"{0} v{1}: {2:d} Barnes and Noble {3} imported from config folder.".format(PLUGIN_NAME, PLUGIN_VERSION, addedkeycount, u"key file" if addedkeycount==1 else u"key files"))
     # Make the json write all the prefs to disk
     dedrmprefs.writeprefs(False)
 
@@ -247,7 +249,7 @@ def convertprefs(always = False):
         dedrmprefs.addnamedvaluetoprefs('adeptkeys', name, value)
     addedkeycount = len(dedrmprefs['adeptkeys'])-priorkeycount
     if addedkeycount > 0:
-        print u"{0} v{1}: {2:d} Adobe Adept {3} imported from config folder.".format(PLUGIN_NAME, PLUGIN_VERSION, addedkeycount, u"keyfile" if addedkeycount==1 else u"keyfiles")
+        print(u"{0} v{1}: {2:d} Adobe Adept {3} imported from config folder.".format(PLUGIN_NAME, PLUGIN_VERSION, addedkeycount, u"keyfile" if addedkeycount==1 else u"keyfiles"))
     # Make the json write all the prefs to disk
     dedrmprefs.writeprefs(False)
 
@@ -260,7 +262,7 @@ def convertprefs(always = False):
         addedkeycount = len(dedrmprefs['bandnkeys']) - priorkeycount
         # no need to delete old prefs, since they contain no recoverable private data
         if addedkeycount > 0:
-            print u"{0} v{1}: {2:d} Barnes and Noble {3} imported from Ignoble plugin preferences.".format(PLUGIN_NAME, PLUGIN_VERSION, addedkeycount, u"key" if addedkeycount==1 else u"keys")
+            print(u"{0} v{1}: {2:d} Barnes and Noble {3} imported from Ignoble plugin preferences.".format(PLUGIN_NAME, PLUGIN_VERSION, addedkeycount, u"key" if addedkeycount==1 else u"keys"))
     # Make the json write all the prefs to disk
     dedrmprefs.writeprefs(False)
 
@@ -277,19 +279,19 @@ def convertprefs(always = False):
             dedrmprefs.addvaluetoprefs('serials',serial)
     addedpidcount = len(dedrmprefs['pids']) - priorpidcount
     if addedpidcount > 0:
-        print u"{0} v{1}: {2:d} {3} imported from Kindle plugin preferences".format(PLUGIN_NAME, PLUGIN_VERSION, addedpidcount, u"PID" if addedpidcount==1 else u"PIDs")
+        print(u"{0} v{1}: {2:d} {3} imported from Kindle plugin preferences".format(PLUGIN_NAME, PLUGIN_VERSION, addedpidcount, u"PID" if addedpidcount==1 else u"PIDs"))
     addedserialcount = len(dedrmprefs['serials']) - priorserialcount
     if addedserialcount > 0:
-        print u"{0} v{1}: {2:d} {3} imported from Kindle plugin preferences".format(PLUGIN_NAME, PLUGIN_VERSION, addedserialcount, u"serial number" if addedserialcount==1 else u"serial numbers")
+        print(u"{0} v{1}: {2:d} {3} imported from Kindle plugin preferences".format(PLUGIN_NAME, PLUGIN_VERSION, addedserialcount, u"serial number" if addedserialcount==1 else u"serial numbers"))
     try:
         if 'wineprefix' in kindleprefs and kindleprefs['wineprefix'] != "":
             dedrmprefs.set('adobewineprefix',kindleprefs['wineprefix'])
             dedrmprefs.set('kindlewineprefix',kindleprefs['wineprefix'])
-            print u"{0} v{1}: WINEPREFIX ‘(2)’ imported from Kindle plugin preferences".format(PLUGIN_NAME, PLUGIN_VERSION, kindleprefs['wineprefix'])
+            print(u"{0} v{1}: WINEPREFIX ‘(2)’ imported from Kindle plugin preferences".format(PLUGIN_NAME, PLUGIN_VERSION, kindleprefs['wineprefix']))
     except:
         traceback.print_exc()
 
 
     # Make the json write all the prefs to disk
     dedrmprefs.writeprefs()
-    print u"{0} v{1}: Finished setting up configuration data.".format(PLUGIN_NAME, PLUGIN_VERSION)
+    print(u"{0} v{1}: Finished setting up configuration data.".format(PLUGIN_NAME, PLUGIN_VERSION))

--- a/DeDRM_plugin/prefs.py
+++ b/DeDRM_plugin/prefs.py
@@ -62,7 +62,7 @@ class DeDRM_Prefs():
 
     def addnamedvaluetoprefs(self, prefkind, keyname, keyvalue):
         try:
-            if keyvalue not in list(self.dedrmprefs[prefkind].values()):
+            if keyvalue not in self.dedrmprefs[prefkind].values():
                 # ensure that the keyname is unique
                 # by adding a number (starting with 2) to the name if it is not
                 namecount = 1

--- a/DeDRM_plugin/utilities.py
+++ b/DeDRM_plugin/utilities.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 
 from ignoblekeygen import generate_key
 

--- a/DeDRM_plugin/wineutils.py
+++ b/DeDRM_plugin/wineutils.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import with_statement
 from __future__ import print_function
 
 from __future__ import absolute_import

--- a/DeDRM_plugin/wineutils.py
+++ b/DeDRM_plugin/wineutils.py
@@ -4,6 +4,7 @@
 from __future__ import with_statement
 from __future__ import print_function
 
+from __future__ import absolute_import
 __license__ = 'GPL v3'
 
 # Standard Python modules.
@@ -14,8 +15,8 @@ def WineGetKeys(scriptpath, extension, wineprefix=""):
     import subprocess
     from subprocess import Popen, PIPE, STDOUT
 
-    import subasyncio
-    from subasyncio import Process
+    from . import subasyncio
+    from .subasyncio import Process
 
     if extension == u".k4i":
         import json
@@ -40,7 +41,7 @@ def WineGetKeys(scriptpath, extension, wineprefix=""):
         cmdline = cmdline.encode(sys.getfilesystemencoding())
         p2 = Process(cmdline, shell=True, bufsize=1, stdin=None, stdout=sys.stdout, stderr=STDOUT, close_fds=False)
         result = p2.wait("wait")
-    except Exception, e:
+    except Exception as e:
         print(u"{0} v{1}: Wine subprocess call error: {2}".format(PLUGIN_NAME, PLUGIN_VERSION, e.args[0]))
         if wineprefix != "" and os.path.exists(wineprefix):
             cmdline = u"WINEPREFIX=\"{2}\" wine C:\\Python27\\python.exe \"{0}\" \"{1}\"".format(scriptpath,outdirpath,wineprefix)
@@ -52,7 +53,7 @@ def WineGetKeys(scriptpath, extension, wineprefix=""):
            cmdline = cmdline.encode(sys.getfilesystemencoding())
            p2 = Process(cmdline, shell=True, bufsize=1, stdin=None, stdout=sys.stdout, stderr=STDOUT, close_fds=False)
            result = p2.wait("wait")
-        except Exception, e:
+        except Exception as e:
            print(u"{0} v{1}: Wine subprocess call error: {2}".format(PLUGIN_NAME, PLUGIN_VERSION, e.args[0]))
 
     # try finding winekeys anyway, even if above code errored

--- a/DeDRM_plugin/zipfix.py
+++ b/DeDRM_plugin/zipfix.py
@@ -20,13 +20,17 @@ from __future__ import absolute_import
 __license__ = 'GPL v3'
 __version__ = "1.1"
 
+import six
 import sys
 import zlib
-from . import zipfilerugged
 import os
 import os.path
 import getopt
 from struct import unpack
+if six.PY3:
+    import zipfile as zipfilerugged
+else:
+    from . import zipfilerugged
 
 
 _FILENAME_LEN_OFFSET = 26

--- a/DeDRM_plugin/zipfix.py
+++ b/DeDRM_plugin/zipfix.py
@@ -16,12 +16,13 @@ Re-write zip (or ePub) fixing problems with file names (and mimetype entry).
 """
 from __future__ import print_function
 
+from __future__ import absolute_import
 __license__ = 'GPL v3'
 __version__ = "1.1"
 
 import sys
 import zlib
-import zipfilerugged
+from . import zipfilerugged
 import os
 import os.path
 import getopt
@@ -49,7 +50,7 @@ class fixZip:
         self.inzip = zipfilerugged.ZipFile(zinput,'r')
         self.outzip = zipfilerugged.ZipFile(zoutput,'w')
         # open the input zip for reading only as a raw file
-        self.bzf = file(zinput,'rb')
+        self.bzf = open(zinput,'rb')
 
     def getlocalname(self, zi):
         local_header_offset = zi.header_offset
@@ -171,7 +172,7 @@ def repairBook(infile, outfile):
         fr = fixZip(infile, outfile)
         fr.fix()
         return 0
-    except Exception, e:
+    except Exception as e:
         print("Error Occurred ", e)
         return 2
 


### PR DESCRIPTION
With these changes, I was able to load the plugin and successfully decrypt an ePub under Calibre 4.12.0 running on Ubuntu 20.04.

I have not changed `adobekeys.py` for the moment. It still worked for me because that script is called through Wine, and I had left the Python that is installed within Wine at version 2.7.

I tried to make as few changes as possible, so many files are left unchanged because I only tried to get ePub decryption to work. I don’t have a way to test the other formats, sorry about that.

Because it was easier, I decided not to convert `zipfilerugged.py` but instead just import the regular `zipfile` module when on Python 3. I don’t know which functionality is lost that way.

To perhaps simplify review, I made a commit after running `python-modernize` on a file, and then a separate commit when I fixed the problems that arose.

I’ve started to work on `adobekey.py` as well, but wanted to get some feedback before I continue.

cc @cclauss @vanicat 