### PR TITLE
Support ebook-convert

### DIFF
--- a/DeDRM_plugin/__init__.py
+++ b/DeDRM_plugin/__init__.py
@@ -127,6 +127,7 @@ class DeDRM(FileTypePlugin):
     minimum_calibre_version = (1, 0, 0)  # Compiled python libraries cannot be imported in earlier versions.
     file_types              = set(['epub','pdf','pdb','prc','mobi','pobi','azw','azw1','azw3','azw4','azw8','tpz','kfx','kfx-zip'])
     on_import               = True
+    on_preprocess           = True
     priority                = 600
 
 


### PR DESCRIPTION
`ebook-convert`  converts ebooks without adding them to the calibre library, and so dedrm_tools fails to run and convert books that are processed in this way. Adding on_preprocess means that it will also run on any preprocessing allowing these tools to be used by the cli tools.

As far as I'm aware, there's nothing wrong with having this run in both instances, and it still seems to allow conversion in the "standard way".