### PR TITLE
Python3fixes

### DIFF
--- a/DeDRM_plugin/config.py
+++ b/DeDRM_plugin/config.py
@@ -153,7 +153,7 @@ class ConfigWidget(QWidget):
             # Copy the HTML helpfile to the plugin directory each time the
             # link is clicked in case the helpfile is updated in newer plugins.
             file_path = os.path.join(config_dir, "plugins", "DeDRM", "help", help_file_name)
-            with open(file_path,'w') as f:
+            with open(file_path,'wb') as f:
                 f.write(self.load_resource(help_file_name))
             return file_path
         url = 'file:///' + get_help_file_resource()
@@ -357,7 +357,7 @@ class ManageKeysDialog(QDialog):
             # link is clicked in case the helpfile is updated in newer plugins.
             help_file_name = "{0}_{1}_Help.htm".format(PLUGIN_NAME, self.key_type_name)
             file_path = os.path.join(config_dir, "plugins", "DeDRM", "help", help_file_name)
-            with open(file_path,'w') as f:
+            with open(file_path,'wb') as f:
                 f.write(self.parent.load_resource(help_file_name))
             return file_path
         url = 'file:///' + get_help_file_resource()

--- a/DeDRM_plugin/config.py
+++ b/DeDRM_plugin/config.py
@@ -431,15 +431,15 @@ class ManageKeysDialog(QDialog):
         defaultname = "{0}.{1}".format(keyname, self.keyfile_ext)
         filename = choose_save_file(self, unique_dlg_name,  caption, filters, all_files=False, initial_filename=defaultname)
         if filename:
-            with file(filename, 'wb') as fname:
+            with open(filename, 'wb') as fname:
                 if self.binary_file:
                     fname.write(self.plugin_keys[keyname].decode('hex'))
                 elif self.json_file:
-                    fname.write(json.dumps(self.plugin_keys[keyname]))
+                    fname.write(json.dumps(self.plugin_keys[keyname]).encode())
                 elif self.android_file:
                     for key in self.plugin_keys[keyname]:
-                        fname.write(key)
-                        fname.write("\n")
+                        fname.write(key.encode())
+                        fname.write(b"\n")
                 else:
                     fname.write(self.plugin_keys[keyname])
 

--- a/DeDRM_plugin/kgenpids.py
+++ b/DeDRM_plugin/kgenpids.py
@@ -52,11 +52,11 @@ def SHA1(message):
 def encode(data, map):
     result = ''
     for char in data:
-        value = ord(char)
+        value = char
         Q = (value ^ 0x80) // len(map)
         R = value % len(map)
-        result += map[Q]
-        result += map[R]
+        result += chr(map[Q])
+        result += chr(map[R])
     return result
 
 # Hash the bytes in data and then encode the digest with the characters in map
@@ -238,18 +238,18 @@ def getK4Pids(rec209, token, kindleDatabase):
                 # Get the UserName we added
                 UserName = bytearray.fromhex((kindleDatabase[1])['UserName']).decode()
                 # encode it
-                encodedUsername = encodeHash(UserName,charMap1)
+                encodedUsername = encodeHash(UserName.encode(),charMap1)
                 #print "encodedUsername",encodedUsername.encode('hex')
         except KeyError:
             print("Keys not found in the database {0}.".format(kindleDatabase[0]))
             return pids
 
         # Get the ID string used
-        encodedIDString = encodeHash(IDString,charMap1)
+        encodedIDString = encodeHash(IDString.encode(),charMap1)
         #print "encodedIDString",encodedIDString.encode('hex')
 
         # concat, hash and encode to calculate the DSN
-        DSN = encode(SHA1(MazamaRandomNumber+encodedIDString+encodedUsername),charMap1)
+        DSN = encode(SHA1((MazamaRandomNumber+encodedIDString+encodedUsername).encode()),charMap1)
         #print "DSN",DSN.encode('hex')
         pass
 


### PR DESCRIPTION
I'm not sure if you already have these fixes. But with these few commits on master I was able to use the plugin successfully to remove drm from kindle ebooks like before on Calibre 4.23 in Calibre 5.1.