### PR TITLE
Python 3 fixes config.py alfcrypto.py

### DIFF
--- a/DeDRM_plugin/alfcrypto.py
+++ b/DeDRM_plugin/alfcrypto.py
@@ -268,10 +268,10 @@ class KeyIVGen(object):
     #                             [c_char_p, c_ulong, c_char_p, c_ulong, c_ulong, c_ulong, c_char_p])
     def pbkdf2(self, passwd, salt, iter, keylen):
 
-        def xorstr( a, b ):
+        def xorbytes( a, b ):
             if len(a) != len(b):
-                raise Exception("xorstr(): lengths differ")
-            return ''.join((chr(ord(x)^ord(y)) for x, y in zip(a, b)))
+                raise Exception("xorbytes(): lengths differ")
+            return bytes([x ^ y for x, y in zip(a, b)])
 
         def prf( h, data ):
             hm = h.copy()
@@ -283,17 +283,17 @@ class KeyIVGen(object):
             T = U
             for i in range(2, itercount+1):
                 U = prf( h, U )
-                T = xorstr( T, U )
+                T = xorbytes( T, U )
             return T
 
         sha = hashlib.sha1
         digest_size = sha().digest_size
         # l - number of output blocks to produce
-        l = int(keylen / digest_size)
+        l = keylen // digest_size
         if keylen % digest_size != 0:
             l += 1
         h = hmac.new( passwd, None, sha )
-        T = ""
+        T = b""
         for i in range(1, l+1):
             T += pbkdf2_F( h, salt, iter, i )
         return T[0: keylen]

--- a/DeDRM_plugin/config.py
+++ b/DeDRM_plugin/config.py
@@ -431,7 +431,7 @@ class ManageKeysDialog(QDialog):
         defaultname = "{0}.{1}".format(keyname, self.keyfile_ext)
         filename = choose_save_file(self, unique_dlg_name,  caption, filters, all_files=False, initial_filename=defaultname)
         if filename:
-            with file(filename, 'wb') as fname:
+            with open(filename, 'w') as fname:
                 if self.binary_file:
                     fname.write(self.plugin_keys[keyname].decode('hex'))
                 elif self.json_file:


### PR DESCRIPTION
Python 3 fix for config.py to make the import/export of key files work in Customize Plugin.
Python 3 fix for alfcrypto.py to make kindlekey.py work. KeyIVGen in kindlekey.py had already be fixed, but the one in alfcrypto.py hasn't. KeyIVGen in alfcrypto.py changed as well to implement existing fix from kindlekey.py.