### PR TITLE
Convert all to bytes first before concat (fix for Windows routine)

### DIFF
--- a/DeDRM_plugin/kindlekey.py
+++ b/DeDRM_plugin/kindlekey.py
@@ -1084,7 +1084,7 @@ if iswindows:
             added_entropy = build + guid
         elif version == 6:  # .kinf2018
             salt = str(0x6d8 * int(build)).encode('utf-8') + guid
-            sp = GetUserName() + '+@#$%+' + GetIDString()
+            sp = GetUserName() + b'+@#$%+' + GetIDString().encode('utf-8')
             passwd = encode(SHA256(sp), charMap5)
             key = KeyIVGen().pbkdf2(passwd, salt, 10000, 0x400)[:32]  # this is very slow
 


### PR DESCRIPTION
Currently this throws error

```
Traceback (most recent call last):
  File "G:\_temp\DeDRM_tools\DeDRM_plugin\kindlekey.py", line 1811, in gui_main
    keys = kindlekeys()
  File "G:\_temp\DeDRM_tools\DeDRM_plugin\kindlekey.py", line 1699, in kindlekeys
    key = getDBfromFile(file)
  File "G:\_temp\DeDRM_tools\DeDRM_plugin\kindlekey.py", line 1087, in getDBfromFile
    sp = GetUserName() + '+@#$%+' + GetIDString()
TypeError: can't concat str to bytes
``` 

because it attempts to concat bytes + string + string. Converts all to bytes first since `SHA256()` requires bytes anyway.

It looks like other rontines don't have this issue, so I guess just someone forgot to change  it for Windows.

Side note: this file really needs some refactoring. Currently some functions return bytes, while similar named ones return string (like `GetIDString` vs `GetIDStrings`, `GetVolumeSerialNumber` vs `GetVolumesSerialNumbers`, etc.).