### PR TITLE
Python 3 fixes

### DIFF
--- a/DeDRM_plugin/config.py
+++ b/DeDRM_plugin/config.py
@@ -6,7 +6,7 @@ __license__ = 'GPL v3'
 # Python 3, September 2020
 
 # Standard Python modules.
-import os, traceback, json, binascii
+import os, traceback, json
 
 from PyQt5.Qt import (Qt, QWidget, QHBoxLayout, QVBoxLayout, QLabel, QLineEdit,
                       QGroupBox, QPushButton, QListWidget, QListWidgetItem,
@@ -378,7 +378,7 @@ class ManageKeysDialog(QDialog):
                 with open(fpath,'rb') as keyfile:
                     new_key_value = keyfile.read()
                 if self.binary_file:
-                    new_key_value = binascii.b2a_hex(new_key_value)
+                    new_key_value = new_key_value.encode('hex')
                 elif self.json_file:
                     new_key_value = json.loads(new_key_value)
                 elif self.android_file:
@@ -431,20 +431,17 @@ class ManageKeysDialog(QDialog):
         defaultname = "{0}.{1}".format(keyname, self.keyfile_ext)
         filename = choose_save_file(self, unique_dlg_name,  caption, filters, all_files=False, initial_filename=defaultname)
         if filename:
-            if self.binary_file:
-                with open(filename, 'wb') as fname:
-                    fname.write(binascii.a2b_hex(self.plugin_keys[keyname]))
-            elif self.json_file:
-                with open(filename, 'w') as fname:
+            with file(filename, 'wb') as fname:
+                if self.binary_file:
+                    fname.write(self.plugin_keys[keyname].decode('hex'))
+                elif self.json_file:
                     fname.write(json.dumps(self.plugin_keys[keyname]))
-            elif self.android_file:
-                with open(filename, 'w') as fname:
+                elif self.android_file:
                     for key in self.plugin_keys[keyname]:
-                        fname.write(key.decode('utf-8'))
-                        fname.write('\n')
-            else:
-                with open(filename, 'w') as fname:
-                    fname.write(self.plugin_keys[keyname].decode('utf-8'))
+                        fname.write(key)
+                        fname.write("\n")
+                else:
+                    fname.write(self.plugin_keys[keyname])
 
 
 
@@ -673,7 +670,7 @@ class AddEReaderDialog(QDialog):
     @property
     def key_value(self):
         from calibre_plugins.dedrm.erdr2pml import getuser_key as generate_ereader_key
-        return binascii.b2a_hex(generate_ereader_key(self.user_name, self.cc_number))
+        return generate_ereader_key(self.user_name,self.cc_number).encode('hex')
 
     @property
     def user_name(self):
@@ -755,7 +752,7 @@ class AddAdeptDialog(QDialog):
 
     @property
     def key_value(self):
-        return binascii.b2a_hex(self.default_key)
+        return self.default_key.encode('hex')
 
 
     def accept(self):

--- a/DeDRM_plugin/config.py
+++ b/DeDRM_plugin/config.py
@@ -6,7 +6,7 @@ __license__ = 'GPL v3'
 # Python 3, September 2020
 
 # Standard Python modules.
-import os, traceback, json
+import os, traceback, json, binascii
 
 from PyQt5.Qt import (Qt, QWidget, QHBoxLayout, QVBoxLayout, QLabel, QLineEdit,
                       QGroupBox, QPushButton, QListWidget, QListWidgetItem,
@@ -378,7 +378,7 @@ class ManageKeysDialog(QDialog):
                 with open(fpath,'rb') as keyfile:
                     new_key_value = keyfile.read()
                 if self.binary_file:
-                    new_key_value = new_key_value.encode('hex')
+                    new_key_value = binascii.b2a_hex(new_key_value)
                 elif self.json_file:
                     new_key_value = json.loads(new_key_value)
                 elif self.android_file:
@@ -431,17 +431,20 @@ class ManageKeysDialog(QDialog):
         defaultname = "{0}.{1}".format(keyname, self.keyfile_ext)
         filename = choose_save_file(self, unique_dlg_name,  caption, filters, all_files=False, initial_filename=defaultname)
         if filename:
-            with file(filename, 'wb') as fname:
-                if self.binary_file:
-                    fname.write(self.plugin_keys[keyname].decode('hex'))
-                elif self.json_file:
+            if self.binary_file:
+                with open(filename, 'wb') as fname:
+                    fname.write(binascii.a2b_hex(self.plugin_keys[keyname]))
+            elif self.json_file:
+                with open(filename, 'w') as fname:
                     fname.write(json.dumps(self.plugin_keys[keyname]))
-                elif self.android_file:
+            elif self.android_file:
+                with open(filename, 'w') as fname:
                     for key in self.plugin_keys[keyname]:
-                        fname.write(key)
-                        fname.write("\n")
-                else:
-                    fname.write(self.plugin_keys[keyname])
+                        fname.write(key.decode('utf-8'))
+                        fname.write('\n')
+            else:
+                with open(filename, 'w') as fname:
+                    fname.write(self.plugin_keys[keyname].decode('utf-8'))
 
 
 
@@ -670,7 +673,7 @@ class AddEReaderDialog(QDialog):
     @property
     def key_value(self):
         from calibre_plugins.dedrm.erdr2pml import getuser_key as generate_ereader_key
-        return generate_ereader_key(self.user_name,self.cc_number).encode('hex')
+        return binascii.b2a_hex(generate_ereader_key(self.user_name, self.cc_number))
 
     @property
     def user_name(self):
@@ -752,7 +755,7 @@ class AddAdeptDialog(QDialog):
 
     @property
     def key_value(self):
-        return self.default_key.encode('hex')
+        return binascii.b2a_hex(self.default_key)
 
 
     def accept(self):

--- a/DeDRM_plugin/erdr2pml.py
+++ b/DeDRM_plugin/erdr2pml.py
@@ -542,10 +542,10 @@ def usage():
     print("  It's enough to enter the last 8 digits of the credit card number")
     return
 
-def getuser_key(name, cc):
+def getuser_key(name,cc):
     newname = "".join(c for c in name.lower() if c >= 'a' and c <= 'z' or c >= '0' and c <= '9')
     cc = cc.replace(" ","")
-    return struct.pack('>LL', binascii.crc32(bytes(newname.encode('utf-8'))) & 0xffffffff, binascii.crc32(bytes(cc[-8:].encode('utf-8'))) & 0xffffffff)
+    return struct.pack('>LL', binascii.crc32(newname) & 0xffffffff,binascii.crc32(cc[-8:])& 0xffffffff)
 
 def cli_main():
     print("eRdr2Pml v{0}. Copyright © 2009–2020 The Dark Reverser et al.".format(__version__))
@@ -580,9 +580,9 @@ def cli_main():
     elif len(args)==4:
         infile, outpath, name, cc = args
 
-    print(bin2ascii.b2a_hex(getuser_key(name, cc)))
+    print(getuser_key(name,cc).encode('hex'))
 
-    return decryptBook(infile, outpath, make_pmlz, bin2ascii.b2a_hex(getuser_key(name, cc)))
+    return decryptBook(infile, outpath, make_pmlz, getuser_key(name,cc))
 
 
 if __name__ == "__main__":

--- a/DeDRM_plugin/erdr2pml.py
+++ b/DeDRM_plugin/erdr2pml.py
@@ -542,10 +542,10 @@ def usage():
     print("  It's enough to enter the last 8 digits of the credit card number")
     return
 
-def getuser_key(name,cc):
+def getuser_key(name, cc):
     newname = "".join(c for c in name.lower() if c >= 'a' and c <= 'z' or c >= '0' and c <= '9')
     cc = cc.replace(" ","")
-    return struct.pack('>LL', binascii.crc32(newname) & 0xffffffff,binascii.crc32(cc[-8:])& 0xffffffff)
+    return struct.pack('>LL', binascii.crc32(bytes(newname.encode('utf-8'))) & 0xffffffff, binascii.crc32(bytes(cc[-8:].encode('utf-8'))) & 0xffffffff)
 
 def cli_main():
     print("eRdr2Pml v{0}. Copyright © 2009–2020 The Dark Reverser et al.".format(__version__))
@@ -580,9 +580,9 @@ def cli_main():
     elif len(args)==4:
         infile, outpath, name, cc = args
 
-    print(getuser_key(name,cc).encode('hex'))
+    print(bin2ascii.b2a_hex(getuser_key(name, cc)))
 
-    return decryptBook(infile, outpath, make_pmlz, getuser_key(name,cc))
+    return decryptBook(infile, outpath, make_pmlz, bin2ascii.b2a_hex(getuser_key(name, cc)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Importing/exporting key files in the Customize panel should work now for all key files, except possibly for B&N, as I don't have any of these.
Decrypting epubs should work as well