### PR TITLE
Fix loading libcrypto on OSX Big Sur

### DIFF
--- a/DeDRM_plugin/kindlekey.py
+++ b/DeDRM_plugin/kindlekey.py
@@ -901,7 +901,7 @@ if iswindows:
                 # double the buffer size
                 buffer = create_unicode_buffer(len(buffer) * 2)
                 size.value = len(buffer)
-            
+
             # replace any non-ASCII values with 0xfffd
             for i in xrange(0,len(buffer)):
                 if buffer[i]>u"\u007f":
@@ -987,7 +987,7 @@ if iswindows:
                 found = True
                 print('Found K4PC 1.25+ kinf2018 file: ' + kinfopath.encode('ascii','ignore'))
                 kInfoFiles.append(kinfopath)
-                
+
             # look for (K4PC 1.9.0 and later) .kinf2011 file
             kinfopath = path +'\\Amazon\\Kindle\\storage\\.kinf2011'
             if os.path.isfile(kinfopath):
@@ -1183,8 +1183,12 @@ elif isosx:
 
         libcrypto = find_library('crypto')
         if libcrypto is None:
-            raise DrmException(u"libcrypto not found")
-        libcrypto = CDLL(libcrypto)
+            libcrypto = '/usr/lib/libcrypto.dylib'
+        try:
+            libcrypto = CDLL(libcrypto)
+        except Exception as e:
+            raise DrmException(u"libcrypto not found: " % e)
+
 
         # From OpenSSL's crypto aes header
         #
@@ -1534,7 +1538,7 @@ elif isosx:
             try:
                 DB = {}
                 items = data.split('/')
-               
+
                 # the headerblob is the encrypted information needed to build the entropy string
                 headerblob = items.pop(0)
                 encryptedValue = decode(headerblob, charMap1)


### PR DESCRIPTION
It looks like Big Sur removed `libcrypto.dylib` as a file on the
filesystem, so loading it using `ctypes.find_library` fails which breaks
Kindle decryption. Now to load a dylib you need to attempt to load it
directly and the operating system will load the dylib from the OS' cache
or fail.

This fixes the problem by explicitly setting the path to libcrypto to
`/usr/lib/libcrypto.dylib` if `ctypes.find_library` does not find the
file, loading the dylib and raising an exception if it fails at that
point.

See saltstack/salt#5778 for more detailed info.

Closes #1369.