### PR TITLE
Add conversion from bytearray to bytes so that pids are hashable

### DIFF
--- a/DeDRM_plugin/k4mobidedrm.py
+++ b/DeDRM_plugin/k4mobidedrm.py
@@ -228,10 +228,7 @@ def GetDecryptedBook(infile, kDatabases, androidFiles, serials, pids, starttime 
         serials.extend(androidkindlekey.get_serials(aFile))
     # extend PID list with book-specific PIDs from seriala and kDatabases
     md1, md2 = mb.getPIDMetaInfo()
-    bookspecific = kgenpids.getPidList(md1, md2, serials, kDatabases)
-    # kgenpids.getPidList returns each pid as a (mutable) bytearray
-    # conversion to (immutable) bytes is nessesary as otherwise the set() function below will fail
-    totalpids.extend((bytes(pid) for pid in bookspecific))
+    totalpids.extend(kgenpids.getPidList(md1, md2, serials, kDatabases))
     # remove any duplicates
     totalpids = list(set(totalpids))
     print("Found {1:d} keys to try after {0:.1f} seconds".format(time.time()-starttime, len(totalpids)))

--- a/DeDRM_plugin/k4mobidedrm.py
+++ b/DeDRM_plugin/k4mobidedrm.py
@@ -228,7 +228,10 @@ def GetDecryptedBook(infile, kDatabases, androidFiles, serials, pids, starttime 
         serials.extend(androidkindlekey.get_serials(aFile))
     # extend PID list with book-specific PIDs from seriala and kDatabases
     md1, md2 = mb.getPIDMetaInfo()
-    totalpids.extend(kgenpids.getPidList(md1, md2, serials, kDatabases))
+    bookspecific = kgenpids.getPidList(md1, md2, serials, kDatabases)
+    # kgenpids.getPidList returns each pid as a (mutable) bytearray
+    # conversion to (immutable) bytes is nessesary as otherwise the set() function below will fail
+    totalpids.extend((bytes(pid) for pid in bookspecific))
     # remove any duplicates
     totalpids = list(set(totalpids))
     print("Found {1:d} keys to try after {0:.1f} seconds".format(time.time()-starttime, len(totalpids)))

--- a/DeDRM_plugin/kgenpids.py
+++ b/DeDRM_plugin/kgenpids.py
@@ -296,14 +296,14 @@ def getPidList(md1, md2, serials=[], kDatabases=[]):
 
     for kDatabase in kDatabases:
         try:
-            pidlst.extend(getK4Pids(md1, md2, kDatabase))
+            pidlst.extend(map(bytes,getK4Pids(md1, md2, kDatabase)))
         except Exception as e:
             print("Error getting PIDs from database {0}: {1}".format(kDatabase[0],e.args[0]))
             traceback.print_exc()
 
     for serialnum in serials:
         try:
-            pidlst.extend(getKindlePids(md1, md2, serialnum))
+            pidlst.extend(map(bytes,getKindlePids(md1, md2, serialnum)))
         except Exception as e:
             print("Error getting PIDs from serial number {0}: {1}".format(serialnum ,e.args[0]))
             traceback.print_exc()


### PR DESCRIPTION
Fixes #1378 and perhaps also #1262 

> Running file type plugin DeDRM failed with traceback:
> Traceback (most recent call last):
>   File "calibre_plugins.dedrm.__init__", line 534, in KindleMobiDecrypt
>   File "calibre_plugins.dedrm.k4mobidedrm", line 236, in GetDecryptedBook
> TypeError: unhashable type: 'bytearray'

The root cause was that `kgenpids.getPidList( ... )` returns PIDs as `bytearray`s which is a mutable type. As such `set()`, which is used to ensure uniqueness, failed. I added a conversion to `bytes` which is an immutable type.

As I have no idea what a PID is in this context, someone a bit more knowledgeable about this library should review if this is a feasible solution. It worked for the books I used it on, but that`s about all I can say with certainty.
