### PR TITLE
Small fix to make Obok help link work.

### DIFF
--- a/Obok_plugin/action.py
+++ b/Obok_plugin/action.py
@@ -197,7 +197,7 @@ class InterfacePluginAction(InterfaceAction):
             # We will write the help file out every time, in case the user upgrades the plugin zip
             # and there is a newer help file contained within it.
             file_path = os.path.join(config_dir, 'plugins', HELPFILE_NAME)
-            file_data = self.load_resources(HELPFILE_NAME)[HELPFILE_NAME]
+            file_data = self.load_resources(HELPFILE_NAME)[HELPFILE_NAME].decode('utf-8')
             with open(file_path,'w') as f:
                 f.write(file_data)
             return file_path


### PR DESCRIPTION
Small fix for Obok plugin to fix clicking on the Help link, and opening it in the browser.