### PR TITLE
Create DeDRM Calibre for KFX-ZIP

### DIFF
--- a/DeDRM Calibre for KFX-ZIP
+++ b/DeDRM Calibre for KFX-ZIP
@@ -1,0 +1,10 @@
+Hello,
+I am a user and bought Kindle ebooks on Amazon. They are KFX-ZIP files. I wanted to use Calibre to convert to epub.
+I used a Kindle PC version 1.24 to import, I charged DeDRM plugin 7.0.0 and a KFX Input from 18/11/20.
+I succeeded to open some ebooks in Calibre as KFX, so I could convert them to epub.
+But I have 4 books bought recently wich remain with KFX-ZIP extensions and I could not do anything in Calibre.
+I don't know what to do because I tried to follow all what explained in this forum.
+If you want I can send you one book which can not be converted.
+Could you please help ?
+Thanks a lot,
+Karine


### PR DESCRIPTION
Impossible to read some KFX-ZIP ebooks
Hello,
I am a user and bought Kindle ebooks on Amazon. They are KFX-ZIP files. I wanted to use Calibre to convert to epub.
I used a Kindle PC version 1.24 to import, I charged DeDRM plugin 7.0.0 and a KFX Input from 18/11/20. I use Calibre 5.7.2
I succeeded to open some ebooks in Calibre as KFX, so I could convert them to epub.
But I have 4 books bought recently wich remain with KFX-ZIP extensions and I could not do anything in Calibre.
I don't know what to do because I tried to follow all what explained in this forum.
If you want I can send you one book which can not be converted.
Could you please help ?
Thanks a lot,
Karine