### PR TITLE
Fix python3 encoding problem in voucher decryption

### DIFF
--- a/DeDRM_plugin/ion.py
+++ b/DeDRM_plugin/ion.py
@@ -815,18 +815,18 @@ class DrmIonVoucher(object):
         addprottable(self.envelope)
 
     def decryptvoucher(self):
-        shared = "PIDv3" + self.encalgorithm + self.enctransformation + self.hashalgorithm
+        shared = ("PIDv3" + self.encalgorithm + self.enctransformation + self.hashalgorithm).encode('ASCII')
 
         self.lockparams.sort()
         for param in self.lockparams:
             if param == "ACCOUNT_SECRET":
-                shared += param + self.secret
+                shared += param.encode('ASCII') + self.secret
             elif param == "CLIENT_ID":
-                shared += param + self.dsn
+                shared += param.encode('ASCII') + self.dsn
             else:
                 _assert(False, "Unknown lock parameter: %s" % param)
 
-        sharedsecret = obfuscate(shared.encode('ASCII'), self.version)
+        sharedsecret = obfuscate(shared, self.version)
 
         key = hmac.new(sharedsecret, b"PIDv3", digestmod=hashlib.sha256).digest()
         aes = AES.new(key[:32], AES.MODE_CBC, self.cipheriv[:16])


### PR DESCRIPTION
Decryption was throwing an error on line 823/825 due to trying to concatenate a string and a bytestring.