### PR TITLE
Fix for broken book keys

### DIFF
--- a/DeDRM_plugin/ineptepub.py
+++ b/DeDRM_plugin/ineptepub.py
@@ -415,12 +415,12 @@ def decryptBook(userkey, inpath, outpath):
                 return 1
             bookkey = rsa.decrypt(codecs.decode(bookkey.encode('ascii'), 'base64'))
             # Padded as per RSAES-PKCS1-v1_5
-            if len(bookkey) != 16:
-                if bookkey[-17] != '\x00' and bookkey[-17] != 0:
+            if len(bookkey) > 16:
+                if bookkey[-17] == '\x00' or bookkey[-17] == 0:
+                    bookkey = bookkey[-16:]
+                else:
                     print("Could not decrypt {0:s}. Wrong key".format(os.path.basename(inpath)))
                     return 2
-                else:
-                    bookkey = bookkey[-16:]
             encryption = inf.read('META-INF/encryption.xml')
             decryptor = Decryptor(bookkey, encryption)
             kwds = dict(compression=ZIP_DEFLATED, allowZip64=False)

--- a/DeDRM_plugin/ineptpdf.py
+++ b/DeDRM_plugin/ineptpdf.py
@@ -1599,11 +1599,10 @@ class PDFDocument(object):
         bookkey = rsa.decrypt(bookkey)
         #if bookkey[0] != 2:
         #    raise ADEPTError('error decrypting book session key')
-        try:
-        	index = bookkey.index(b'\0') + 1
-        	bookkey = bookkey[index:]
-        except ValueError:
-        	pass
+        if len(bookkey) > 16:
+            if bookkey[-17] == '\x00' or bookkey[-17] == 0:
+                bookkey = bookkey[-16:]
+                length = 16
         ebx_V = int_value(param.get('V', 4))
         ebx_type = int_value(param.get('EBX_ENCRYPTIONTYPE', 6))
         # added because of improper booktype / decryption book session key errors


### PR DESCRIPTION
Lines 1603, and 1604 in ineptpdf.py split the decrypted key on any 0 present to create the book key. ineptepub.py has similar code, but here the key is split only when the key is longer than 16 bytes, and the byte 17 from last is 0. The code in ineptpdf.py generates incorrect keys when the key is already 16 bytes long and contains a 0. This change should fix that.