### PR TITLE
Fix for Python 3

### DIFF
--- a/DeDRM_plugin/ineptpdf.py
+++ b/DeDRM_plugin/ineptpdf.py
@@ -442,7 +442,7 @@ def nunpack(s, default=0):
     elif l == 2:
         return struct.unpack('>H', s)[0]
     elif l == 3:
-        return struct.unpack('>L', '\x00'+s)[0]
+        return struct.unpack('>L', b'\x00'+s)[0]
     elif l == 4:
         return struct.unpack('>L', s)[0]
     else:


### PR DESCRIPTION
@dreikin reported in issue #1519 that trying to decrypt a PDF ebook caused an error in line 445:

`        return struct.unpack('>L', '\x00'+s)[0]`

The traceback mentions that s is a byte array that's added to a string. so that should most likely have been something like this:

`        return struct.unpack('>L', b'\x00'+s)[0]`

It looks like this PDF isn't quite the same as the PDF's I have, it tried to run a part of the code that mine didn't, so I can't test it, but this change should fix this error.