### PR TITLE
Support Python 2.7 and Python 3 winreg imports on Windows

### DIFF
--- a/DeDRM_plugin/adobekey.py
+++ b/DeDRM_plugin/adobekey.py
@@ -111,7 +111,10 @@ if iswindows:
         c_long, c_ulong
 
     from ctypes.wintypes import LPVOID, DWORD, BOOL
-    import winreg
+    try:
+        import winreg
+    except ImportError:
+        import _winreg as winreg
 
     def _load_crypto_libcrypto():
         from ctypes.util import find_library

--- a/DeDRM_plugin/ignoblekey.py
+++ b/DeDRM_plugin/ignoblekey.py
@@ -95,7 +95,10 @@ def getNookLogFiles():
     logFiles = []
     found = False
     if iswindows:
-        import winreg
+        try:
+            import winreg
+        except ImportError:
+            import _winreg as winreg
 
         # some 64 bit machines do not have the proper registry key for some reason
         # or the python interface to the 32 vs 64 bit registry is broken

--- a/DeDRM_plugin/kindlekey.py
+++ b/DeDRM_plugin/kindlekey.py
@@ -189,7 +189,11 @@ if iswindows:
         create_unicode_buffer, create_string_buffer, CFUNCTYPE, addressof, \
         string_at, Structure, c_void_p, cast
 
-    import winreg
+    try:
+        import winreg
+    except ImportError:
+        import _winreg as winreg
+
     MAX_PATH = 255
     kernel32 = windll.kernel32
     advapi32 = windll.advapi32

--- a/DeDRM_plugin/simpleprefs.py
+++ b/DeDRM_plugin/simpleprefs.py
@@ -20,7 +20,10 @@ class SimplePrefs(object):
             self.file2key[filename] = key
         self.target = target + 'Prefs'
         if sys.platform.startswith('win'):
-            import winreg
+            try:
+                import winreg
+            except ImportError:
+                import _winreg as winreg
             regkey = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\Shell Folders\\")
             path = winreg.QueryValueEx(regkey, 'Local AppData')[0]
             prefdir = path + os.sep + self.target

--- a/Obok_plugin/obok/legacy_obok.py
+++ b/Obok_plugin/obok/legacy_obok.py
@@ -42,7 +42,10 @@ class legacy_obok(object):
         pwsdid = ''
         try:
             if sys.platform.startswith('win'):
-                import winreg
+                try:
+                    import winreg
+                except ImportError:
+                    import _winreg as winreg
                 regkey_browser = winreg.OpenKey(winreg.HKEY_CURRENT_USER, 'Software\\Kobo\\Kobo Desktop Edition\\Browser')
                 cookies = winreg.QueryValueEx(regkey_browser, 'cookies')
                 bytearrays = cookies[0]

--- a/Obok_plugin/obok/obok.py
+++ b/Obok_plugin/obok/obok.py
@@ -356,7 +356,10 @@ class KoboLibrary(object):
 
             if (self.kobodir == u""):
                 if sys.platform.startswith('win'):
-                    import winreg
+                    try:
+                        import winreg
+                    except ImportError:
+                        import _winreg as winreg
                     if sys.getwindowsversion().major > 5:
                         if 'LOCALAPPDATA' in os.environ.keys():
                             # Python 2.x does not return unicode env. Use Python 3.x

--- a/Other_Tools/DRM_Key_Scripts/Adobe_Digital_Editions/adobekey.pyw
+++ b/Other_Tools/DRM_Key_Scripts/Adobe_Digital_Editions/adobekey.pyw
@@ -129,7 +129,10 @@ if iswindows:
         c_long, c_ulong
 
     from ctypes.wintypes import LPVOID, DWORD, BOOL
-    import winreg
+    try:
+        import winreg
+    except ImportError:
+        import _winreg as winreg
 
     def _load_crypto_libcrypto():
         from ctypes.util import find_library

--- a/Other_Tools/DRM_Key_Scripts/Barnes_and_Noble_ePubs/ignoblekey.pyw
+++ b/Other_Tools/DRM_Key_Scripts/Barnes_and_Noble_ePubs/ignoblekey.pyw
@@ -98,7 +98,10 @@ def getNookLogFiles():
     logFiles = []
     found = False
     if iswindows:
-        import winreg
+        try:
+            import winreg
+        except ImportError:
+            import _winreg as winreg
 
         # some 64 bit machines do not have the proper registry key for some reason
         # or the python interface to the 32 vs 64 bit registry is broken

--- a/Other_Tools/DRM_Key_Scripts/Kindle_for_Mac_and_PC/kindlekey.pyw
+++ b/Other_Tools/DRM_Key_Scripts/Kindle_for_Mac_and_PC/kindlekey.pyw
@@ -177,7 +177,10 @@ if iswindows:
         create_unicode_buffer, create_string_buffer, CFUNCTYPE, addressof, \
         string_at, Structure, c_void_p, cast
 
-    import winreg
+    try:
+        import winreg
+    except ImportError:
+        import _winreg as winreg
     MAX_PATH = 255
     kernel32 = windll.kernel32
     advapi32 = windll.advapi32

--- a/Other_Tools/Kobo/obok.py
+++ b/Other_Tools/Kobo/obok.py
@@ -346,7 +346,10 @@ class KoboLibrary(object):
         if (self.kobodir == u""):
             # step 4. we haven't found a device with serials, so try desktop apps
             if sys.platform.startswith('win'):
-                import winreg
+                try:
+                    import winreg
+                except ImportError:
+                    import _winreg as winreg
                 if sys.getwindowsversion().major > 5:
                     if 'LOCALAPPDATA' in os.environ.keys():
                         # Python 2.x does not return unicode env. Use Python 3.x


### PR DESCRIPTION
Wraps the `winreg` import in a try statement in order to gracefully support the `_winreg` -> `winreg` name change from Python 2.7 to Python 3.

```python
try:
    import winreg
except ImportError:
    import _winreg as winreg
```