### PR TITLE
Fix in keyfetch for obok on win10

### DIFF
--- a/Obok_plugin/obok/obok.py
+++ b/Obok_plugin/obok/obok.py
@@ -470,8 +470,8 @@ class KoboLibrary(object):
         """The list of all MAC addresses on this machine."""
         macaddrs = []
         if sys.platform.startswith('win'):
-            c = re.compile('\s(' + '[0-9a-f]{2}-' * 5 + '[0-9a-f]{2})(\s|$)', re.IGNORECASE)
-            output = subprocess.Popen('ipconfig /all', shell=True, stdout=subprocess.PIPE, text=True).stdout
+            c = re.compile('\s?(' + '[0-9a-f]{2}[:\-]' * 5 + '[0-9a-f]{2})(\s|$)', re.IGNORECASE)
+            output = subprocess.Popen('wmic nic where PhysicalAdapter=True get MACAddress', shell=True, stdout=subprocess.PIPE, text=True).stdout
             for line in output:
                 m = c.search(line)
                 if m:


### PR DESCRIPTION
According to calibre debug the ipconfig command returned some invalid utf-8 characters (I think is maybe an issue due to the Python2 switch-off as the 4.x version worked fine).
To solve this on my machine I've changed the external call and modified the regex to match both the output of "ipconfig" and that of "wmic".