### PR TITLE
Fix in keyfetch for obok on MacOS

### DIFF
--- a/Obok_plugin/obok/obok.py
+++ b/Obok_plugin/obok/obok.py
@@ -478,7 +478,7 @@ class KoboLibrary(object):
                     macaddrs.append(re.sub("-", ":", m.group(1)).upper())
         elif sys.platform.startswith('darwin'):
             c = re.compile('\s(' + '[0-9a-f]{2}:' * 5 + '[0-9a-f]{2})(\s|$)', re.IGNORECASE)
-            output = subprocess.check_output('/sbin/ifconfig -a', shell=True)
+            output = subprocess.check_output('/sbin/ifconfig -a', shell=True, encoding='utf-8')
             matches = c.findall(output)
             for m in matches:
                 # print "m:{0}".format(m[0])


### PR DESCRIPTION
 Another commit concerning the issue  #1580. Similarly to the proposed change for Windows 
 support in #1575 this fix adds support for Darwin/MacOS. Tested on MacOS 11.2.2 with Calibre 5.12.
 
 Issue:
 With the move to Python 3 the methods reading  Mac addresses now return 
 Byte Streams, while the Regular Expressions expect text inputs.
 
```
c = re.compile('\s(' + '[0-9a-f]{2}:' * 5 + '[0-9a-f]{2})(\s|$)', re.IGNORECASE) # Text Stream 
output = subprocess.check_output('/sbin/ifconfig -a', shell=True) # Byte Stream
matches = c.findall(output) # conflict
``` 

Solution:
Conversion into an UTF-8 encoded Text Stream. 

 
