### PR TITLE
Python 3.x fix

### DIFF
--- a/DeDRM_plugin/kgenpids.py
+++ b/DeDRM_plugin/kgenpids.py
@@ -209,7 +209,7 @@ def getK4Pids(rec209, token, kindleDatabase):
         kindleAccountToken = bytearray.fromhex((kindleDatabase[1])['kindle.account.tokens'])
 
     except KeyError:
-        kindleAccountToken=""
+        kindleAccountToken = b''
         pass
 
     try:


### PR DESCRIPTION
It fails on line 270: `pidHash = SHA1(DSN+kindleAccountToken+rec209+token)` because it attempts to do bytes + string 