### PR TITLE
Fix regresson in obok on certain win10 machines

### DIFF
--- a/Obok_plugin/obok/obok.py
+++ b/Obok_plugin/obok/obok.py
@@ -471,11 +471,18 @@ class KoboLibrary(object):
         macaddrs = []
         if sys.platform.startswith('win'):
             c = re.compile('\s?(' + '[0-9a-f]{2}[:\-]' * 5 + '[0-9a-f]{2})(\s|$)', re.IGNORECASE)
-            output = subprocess.Popen('wmic nic where PhysicalAdapter=True get MACAddress', shell=True, stdout=subprocess.PIPE, text=True).stdout
-            for line in output:
-                m = c.search(line)
-                if m:
-                    macaddrs.append(re.sub("-", ":", m.group(1)).upper())
+            try: 
+                output = subprocess.Popen('ipconfig /all', shell=True, stdout=subprocess.PIPE, text=True).stdout
+                for line in output:
+                    m = c.search(line)
+                    if m:
+                        macaddrs.append(re.sub("-", ":", m.group(1)).upper())
+            except:
+                output = subprocess.Popen('wmic nic where PhysicalAdapter=True get MACAddress', shell=True, stdout=subprocess.PIPE, text=True).stdout
+                for line in output:
+                    m = c.search(line)
+                    if m:
+                        macaddrs.append(re.sub("-", ":", m.group(1)).upper())
         elif sys.platform.startswith('darwin'):
             c = re.compile('\s(' + '[0-9a-f]{2}:' * 5 + '[0-9a-f]{2})(\s|$)', re.IGNORECASE)
             output = subprocess.check_output('/sbin/ifconfig -a', shell=True, encoding='utf-8')


### PR DESCRIPTION
Aim to fix the problem reported in issue #1673
As that problem presents using the new implementation for __getmacaddrs on certain machines (fails the key fetch without raising any error), while the old implementation thows an exception in output line parsing conversion.
The fix uses by default the 7.1.0 implementation, wrapping it in a try-except block and using the 7.2.1 impl only when the old impl fails.