### PR TITLE
revert winreg rename for kindlekey.pyw

### DIFF
--- a/Other_Tools/DRM_Key_Scripts/Kindle_for_Mac_and_PC/kindlekey.pyw
+++ b/Other_Tools/DRM_Key_Scripts/Kindle_for_Mac_and_PC/kindlekey.pyw
@@ -177,7 +177,7 @@ if iswindows:
         create_unicode_buffer, create_string_buffer, CFUNCTYPE, addressof, \
         string_at, Structure, c_void_p, cast
 
-    import winreg
+    import _winreg as winreg
     MAX_PATH = 255
     kernel32 = windll.kernel32
     advapi32 = windll.advapi32


### PR DESCRIPTION
As the script isn't python3 compatible yet, we still need to
import _winreg to make it run at least with python2.7.

To make it run with python3, we need more works around
print and raise syntax.