### PR TITLE
Add support for ACSM->EPUB converted files

### DIFF
--- a/DeDRM_plugin/__init__.py
+++ b/DeDRM_plugin/__init__.py
@@ -132,7 +132,7 @@ class DeDRM(FileTypePlugin):
     author                  = "Apprentice Alf, Aprentice Harper, The Dark Reverser and i♥cabbages"
     version                 = PLUGIN_VERSION_TUPLE
     minimum_calibre_version = (5, 0, 0)  # Python 3.
-    file_types              = set(['epub','pdf','pdb','prc','mobi','pobi','azw','azw1','azw3','azw4','azw8','tpz','kfx','kfx-zip'])
+    file_types              = set(['epub','pdf','pdb','prc','mobi','pobi','azw','azw1','azw3','azw4','azw8','tpz','kfx','kfx-zip','acsm'])
     on_import               = True
     on_preprocess           = True
     priority                = 600


### PR DESCRIPTION
Now, this single-line change might look incredibly useless at first glance (the tools don't support .acsm files) but there's more to that change. 

A couple days ago I created a [Calibre FileType plugin](https://github.com/Leseratte10/acsm-calibre-plugin) that adds support for ACSM files to Calibre. Meaning, you can authorize Calibre with an AdobeID and then just drag-and-drop an ACSM file into Calibre and it'll turn into an EPUB, which is way, way easier than having to deal with Adobe Digital Editions, especially on Linux.

Unfortunately, with multiple FileType plugins, Calibre first determines a list of plugins to run depending on the file type, and then runs all of them in order. So because the DeDRM plugin doesn't advertise "acsm" as a supported file extension, it doesn't run on the new ebook even though it has been converted from acsm to epub and the plugin could handle it just fine. I've [reported this bug](https://bugs.launchpad.net/calibre/+bug/1944089), but that report has been closed as "Won't fix, not a bug". 

This would mean that people would need to add the ACSM file to Calibre to turn it into an EPUB, then copy that EPUB out of Calibre, and then add it back to calibre to have the DeDRM plugin run over the book.

By adding "acsm" to the list of supported file types Calibre will run the DeDRM plugin after the book's been turned into an epub (because my plugin has a higher priority value than this one), and in the `run` function in `__init__.py` it will then use the actual file extension the book has, which would be "epub". 

So, this change means that people using my ACSM plugin can just drag-and-drop ACSM files into Calibre and have then automatically turn into DRM-free EPUBs if the DeDRM plugin is installed, too. 
For people not using my plugin, this change doesn't affect anything. If you'd drag an ACSM file into Calibre with the current version, the DeDRM plugin wouldn't run at all, and with this PR applied, the plugin would run, immediately notice that it can't do anything with ACSM files, and return without doing anything; so unless I'm missing something there should be no harm in adding this change. 

EDIT: Also, is this plugin still being maintained? There's a bunch of PRs with bugfixes but the last commit on master was in April ...