### PR TITLE
Fix typo in kindlekey.py that broke Mac version

### DIFF
--- a/DeDRM_plugin/kindlekey.py
+++ b/DeDRM_plugin/kindlekey.py
@@ -1516,7 +1516,7 @@ elif isosx:
             b'SerialNumber',\
             b'UsernameHash',\
             b'kindle.directedid.info',\
-            b'DSN'
+            b'DSN',\
             b'kindle.accounttype.info',\
             b'krx.flashcardsplugin.data.encryption_key',\
             b'krx.notebookexportplugin.data.encryption_key',\


### PR DESCRIPTION
A typo in the name list of kindlekey.py caused the Mac version to malfunction. This commit fixes the typo.