### PR TITLE
Fix username code for ADE key retrieval

### DIFF
--- a/DeDRM_plugin/adobekey.py
+++ b/DeDRM_plugin/adobekey.py
@@ -228,6 +228,20 @@ if iswindows:
         return GetUserName
     GetUserName = GetUserName()
 
+    def GetUserName2():
+        try:
+            import winreg
+        except ImportError:
+            import _winreg as winreg
+
+        try: 
+            DEVICE_KEY_PATH = r'Software\Adobe\Adept\Device'
+            regkey = winreg.OpenKey(winreg.HKEY_CURRENT_USER, DEVICE_KEY_PATH)
+            userREG = winreg.QueryValueEx(regkey, 'username')[0].encode('utf-16-le')[::2]
+            return userREG
+        except: 
+            return None
+
     PAGE_EXECUTE_READWRITE = 0x40
     MEM_COMMIT  = 0x1000
     MEM_RESERVE = 0x2000
@@ -351,7 +365,9 @@ if iswindows:
         serial = GetVolumeSerialNumber(root)
         vendor = cpuid0()
         signature = struct.pack('>I', cpuid1())[1:]
-        user = GetUserName()
+        user = GetUserName2()
+        if user is None: 
+            user = GetUserName()
         entropy = struct.pack('>I12s3s13s', serial, vendor, signature, user)
         cuser = winreg.HKEY_CURRENT_USER
         try:


### PR DESCRIPTION
There have been lots of reports of the error message "Failed to decrypt user key key (sic)" in the past. Looking at the source code, this error occurs when the Windows API call to `CryptUnprotectData` fails. This can happen if the entropy data is wrong. 

ADE uses the Windows user name as part of that entropy data, and the script previously used the Windows API function `GetUserNameW` to retrieve the user's current user name. 

However, this breaks when the user account has been renamed between ADE install and plugin usage. The key will be encrypted using the old name as entropy, but the python script will try to decrypt the key with the new current name, which will obviously fail. 

Thankfully, ADE stores the user name (as it was at authorization time) in the registry - probably because ADE needs that info itself to access the key, so all that's needed to fix this is to read the user name from the registry instead of relying on Windows API. 

This should be a proper fix (rather than the current workaround of "reinstall and re-authorize ADE") for #186, #252, #262, #278, #309, #348, #349, #371, #436, #471, #668, #708, #759, #815, #902, #1109, #1144, #1395 and #1938, all of which seem to be duplicates of eachother. 